### PR TITLE
feat: d2-modal-uiOnly

### DIFF
--- a/src/app/(dashboard)/educators/exams/[examId]/grading/_components/StudentListSidebar.tsx
+++ b/src/app/(dashboard)/educators/exams/[examId]/grading/_components/StudentListSidebar.tsx
@@ -9,13 +9,15 @@ import { GradingStudent } from "@/types/grading";
 type StudentListSidebarProps = {
   students: GradingStudent[];
   selectedStudentId?: string;
-  onSelectStudent?: (studentId: string) => void;
+  onSelectStudentAction?: (studentId: string) => void;
+  onOpenResultModalAction?: () => void;
 };
 
 export function StudentListSidebar({
   students,
   selectedStudentId,
-  onSelectStudent,
+  onSelectStudentAction,
+  onOpenResultModalAction,
 }: StudentListSidebarProps) {
   const isAllSaved =
     students.length > 0 &&
@@ -42,7 +44,7 @@ export function StudentListSidebar({
               className={`cursor-pointer transition-colors ${
                 isSelected ? "bg-primary/10 border-primary" : ""
               }`}
-              onClick={() => onSelectStudent?.(student.id)}
+              onClick={() => onSelectStudentAction?.(student.id)}
             >
               <CardContent className="p-4">
                 <div className="space-y-1">
@@ -59,7 +61,12 @@ export function StudentListSidebar({
       </div>
 
       <div className="space-y-2">
-        <Button className="w-full" size="lg" disabled={!isAllSaved}>
+        <Button
+          className="w-full"
+          size="lg"
+          disabled={!isAllSaved}
+          onClick={onOpenResultModalAction}
+        >
           <Check className="h-4 w-4 mr-2" />
           전체 완료
         </Button>

--- a/src/app/(dashboard)/educators/exams/[examId]/grading/_modals/grading-result/GradingResultModal.tsx
+++ b/src/app/(dashboard)/educators/exams/[examId]/grading/_modals/grading-result/GradingResultModal.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+
+import { GradingResultSummary } from "./GradingResultSummary";
+import { StudentScoreTable } from "./StudentScoreTable";
+import { QuestionStatsTable } from "./QuestionStatsTable";
+import {
+  GradingReportOverview,
+  GradingReportQuestionStat,
+  GradingReportStudentRow,
+} from "./types";
+
+type GradingResultModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  subtitle: string;
+  overview: GradingReportOverview;
+  studentRows: GradingReportStudentRow[];
+  questionStats: GradingReportQuestionStat[];
+};
+
+export function GradingResultModal({
+  open,
+  onOpenChange,
+  title,
+  subtitle,
+  overview,
+  studentRows,
+  questionStats,
+}: GradingResultModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-5xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader className="text-left space-y-1">
+          <DialogTitle className="text-2xl font-bold">{title}</DialogTitle>
+          <p className="text-sm text-muted-foreground">
+            {subtitle} · {overview.examDate}
+          </p>
+        </DialogHeader>
+
+        <Separator />
+
+        <div className="space-y-5">
+          <GradingResultSummary overview={overview} />
+          <StudentScoreTable rows={studentRows} />
+          <QuestionStatsTable stats={questionStats} />
+        </div>
+
+        <Separator />
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            취소
+          </Button>
+          <Button onClick={() => onOpenChange(false)}>최종 저장</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(dashboard)/educators/exams/[examId]/grading/_modals/grading-result/GradingResultSummary.tsx
+++ b/src/app/(dashboard)/educators/exams/[examId]/grading/_modals/grading-result/GradingResultSummary.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+
+import { GradingReportOverview } from "./types";
+
+type GradingResultSummaryProps = {
+  overview: GradingReportOverview;
+};
+
+export function GradingResultSummary({ overview }: GradingResultSummaryProps) {
+  return (
+    <Card className="bg-muted/30">
+      <CardContent className="p-6">
+        <div className="grid grid-cols-4 gap-8">
+          <div className="space-y-1">
+            <p className="text-sm text-muted-foreground">시험 일자</p>
+            <p className="text-lg font-semibold">{overview.examDate}</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm text-muted-foreground">평균</p>
+            <p className="text-lg font-semibold">{overview.averageScore}</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm text-muted-foreground">상위 30% 평균</p>
+            <p className="text-lg font-semibold">
+              {overview.top30AverageScore}
+            </p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm text-muted-foreground">최고점수</p>
+            <p className="text-lg font-semibold">{overview.maxScore}</p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/educators/exams/[examId]/grading/_modals/grading-result/QuestionStatsTable.tsx
+++ b/src/app/(dashboard)/educators/exams/[examId]/grading/_modals/grading-result/QuestionStatsTable.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+import { GradingReportQuestionStat } from "./types";
+
+type QuestionStatsTableProps = {
+  stats: GradingReportQuestionStat[];
+};
+
+function RateCell({ value }: { value: number }) {
+  const text =
+    value === 0 ? "0%" : value === 100 ? "100%" : `${Math.round(value)}%`;
+  return <span className="tabular-nums">{text}</span>;
+}
+
+export function QuestionStatsTable({ stats }: QuestionStatsTableProps) {
+  return (
+    <Card className="bg-muted/30">
+      <CardContent className="p-0">
+        <div className="px-6 pt-5 pb-3">
+          <p className="text-sm font-semibold">문항별 오답률</p>
+        </div>
+
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-muted/40 hover:bg-muted/40">
+              <TableHead className="px-6 py-3">문제번호</TableHead>
+              <TableHead className="py-3">정답률</TableHead>
+              <TableHead className="py-3">오답률</TableHead>
+              <TableHead className="py-3">1번</TableHead>
+              <TableHead className="py-3">2번</TableHead>
+              <TableHead className="py-3">3번</TableHead>
+              <TableHead className="py-3">4번</TableHead>
+              <TableHead className="py-3 pr-6">5번</TableHead>
+            </TableRow>
+          </TableHeader>
+
+          <TableBody>
+            {stats.map((row) => (
+              <TableRow key={row.questionNumber}>
+                <TableCell className="px-6 py-4 font-semibold">
+                  {row.questionNumber}
+                </TableCell>
+                <TableCell className="py-4 text-emerald-600">
+                  <RateCell value={row.correctRate} />
+                </TableCell>
+                <TableCell className="py-4 text-red-600">
+                  <RateCell value={row.wrongRate} />
+                </TableCell>
+                {row.optionRates.map((rate, idx) => (
+                  <TableCell
+                    key={`${row.questionNumber}-${idx}`}
+                    className={idx === 4 ? "py-4 pr-6" : "py-4"}
+                  >
+                    <RateCell value={rate} />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/educators/exams/[examId]/grading/_modals/grading-result/StudentScoreTable.tsx
+++ b/src/app/(dashboard)/educators/exams/[examId]/grading/_modals/grading-result/StudentScoreTable.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+import { GradingReportStudentRow } from "./types";
+
+type StudentScoreTableProps = {
+  rows: GradingReportStudentRow[];
+};
+
+export function StudentScoreTable({ rows }: StudentScoreTableProps) {
+  return (
+    <Card className="bg-muted/30">
+      <CardContent className="p-0">
+        <div className="px-6 pt-5 pb-3">
+          <p className="text-sm font-semibold">학생별 성적</p>
+        </div>
+
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-muted/40 hover:bg-muted/40">
+              <TableHead className="px-6 py-3">이름</TableHead>
+              <TableHead className="py-3">정답개수</TableHead>
+              <TableHead className="py-3">점수(배점식)</TableHead>
+              <TableHead className="py-3 text-right pr-6">석차</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.id}>
+                <TableCell className="px-6 py-4 font-medium">
+                  {row.name}
+                </TableCell>
+                <TableCell className="py-4">{row.correctCount}</TableCell>
+                <TableCell className="py-4">{row.score}</TableCell>
+                <TableCell className="py-4 text-right pr-6">
+                  {row.rank}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+
+        <div className="flex justify-center py-4">
+          <Button variant="outline" className="gap-2" disabled>
+            더보기 ({rows.length}/{rows.length})
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/educators/exams/[examId]/grading/_modals/grading-result/types.ts
+++ b/src/app/(dashboard)/educators/exams/[examId]/grading/_modals/grading-result/types.ts
@@ -1,0 +1,21 @@
+export type GradingReportOverview = {
+  examDate: string;
+  averageScore: number;
+  top30AverageScore: number;
+  maxScore: number;
+};
+
+export type GradingReportStudentRow = {
+  id: string;
+  name: string;
+  correctCount: string;
+  score: number;
+  rank: string;
+};
+
+export type GradingReportQuestionStat = {
+  questionNumber: number;
+  correctRate: number;
+  wrongRate: number;
+  optionRates: number[];
+};

--- a/src/app/(dashboard)/educators/exams/[examId]/grading/page.tsx
+++ b/src/app/(dashboard)/educators/exams/[examId]/grading/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
 import { Button } from "@/components/ui/button";
 import {
   mockGradingExamInfo,
   mockGradingQuestions,
+  mockGradingReportOverview,
+  mockGradingReportQuestionStats,
+  mockGradingReportStudentRows,
   mockGradingStudents,
   mockGradingSummary,
 } from "@/data/grading.mock";
@@ -12,9 +17,30 @@ import { GradingPageHeader } from "./_components/GradingPageHeader";
 import { StudentListSidebar } from "./_components/StudentListSidebar";
 import { GradingSummaryCards } from "./_components/GradingSummaryCards";
 import { QuestionAnswerList } from "./_components/QuestionAnswerList";
+import { GradingResultModal } from "./_modals/grading-result/GradingResultModal";
 
 export default function GradingPage() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const modal = searchParams.get("modal");
+  const isResultModalOpen = modal === "result";
+
   const selectedStudentId = mockGradingStudents[0]?.id ?? "";
+
+  const openResultModal = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("modal", "result");
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname);
+  };
+
+  const closeResultModal = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("modal");
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname);
+  };
 
   return (
     <div className="container mx-auto p-6">
@@ -29,6 +55,7 @@ export default function GradingPage() {
         <StudentListSidebar
           students={mockGradingStudents}
           selectedStudentId={selectedStudentId}
+          onOpenResultModalAction={openResultModal}
         />
 
         {/* 오른쪽: 메인 영역 */}
@@ -59,6 +86,16 @@ export default function GradingPage() {
           )}
         </div>
       </div>
+
+      <GradingResultModal
+        open={isResultModalOpen}
+        onOpenChange={(open) => (open ? openResultModal() : closeResultModal())}
+        title={mockGradingExamInfo.examName}
+        subtitle={`${mockGradingExamInfo.examSubtitle} ${mockGradingExamInfo.examName}`}
+        overview={mockGradingReportOverview}
+        studentRows={mockGradingReportStudentRows}
+        questionStats={mockGradingReportQuestionStats}
+      />
     </div>
   );
 }

--- a/src/data/grading.mock.ts
+++ b/src/data/grading.mock.ts
@@ -242,3 +242,71 @@ export const mockGradingSummary: GradingSummary = {
   correctRate: 0,
   isPassed: false,
 };
+
+/**
+ * D2 결과(시험 리포트) 모달 UI용 mock
+ * - 기능 연동 전, 디자인 검증/PR 목적
+ */
+export const mockGradingReportOverview = {
+  examDate: "2026-01-13",
+  averageScore: 80,
+  top30AverageScore: 100,
+  maxScore: 100,
+};
+
+export const mockGradingReportStudentRows = [
+  {
+    id: "stu-001",
+    name: "구민지",
+    correctCount: "5/5",
+    score: 100,
+    rank: "1 / 3",
+  },
+  {
+    id: "stu-002",
+    name: "유지현",
+    correctCount: "3/5",
+    score: 60,
+    rank: "3 / 3",
+  },
+  {
+    id: "stu-003",
+    name: "이서윤",
+    correctCount: "4/5",
+    score: 80,
+    rank: "2 / 3",
+  },
+];
+
+export const mockGradingReportQuestionStats = [
+  {
+    questionNumber: 1,
+    correctRate: 100,
+    wrongRate: 0,
+    optionRates: [100, 0, 0, 0, 0],
+  },
+  {
+    questionNumber: 2,
+    correctRate: 67,
+    wrongRate: 33,
+    optionRates: [0, 67, 33, 0, 0],
+  },
+  {
+    questionNumber: 3,
+    correctRate: 100,
+    wrongRate: 0,
+    optionRates: [0, 0, 100, 0, 0],
+  },
+  {
+    questionNumber: 4,
+    correctRate: 67,
+    wrongRate: 33,
+    optionRates: [0, 33, 0, 67, 0],
+  },
+  {
+    questionNumber: 5,
+    correctRate: 67,
+    wrongRate: 33,
+    optionRates: [33, 0, 0, 0, 67],
+  },
+];


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #46 

## ✨ 작업 단계 및 변경 사항

- **작업 단계:** Phase 1 (UI-only, 기능/저장/API 미연동)
- **변경 사항:**

     - D2-(1) 시험 리포트 모달 UI 추가 및 _modals/
        grading-result로 분리
      - ?modal=result 쿼리로 모달 오픈/클로즈 동기화
        (router.replace로 히스토리 최소화)
      - 사이드바 “전체 완료” 버튼에서 모달 오픈 액션 연
        결
      - 리포트 모달 UI용 mock 데이터 추가

## 🧪 테스트 방법

리뷰어가 확인해야 할 핵심 포인트를 적어주세요.

 - [ ] /educators/exams/1/grading?modal=result 접속 →  모달 오픈 확인
  - [ ] 모달 “취소” 클릭 시 쿼리 제거 및 모달 닫힘 확인
  - [ ] 사이드바 “전체 완료” 버튼 활성화 조건(현재는 모
    든 학생 임시 저장) 확인

## 📸 스크린샷 (선택)

<img width="1031" height="911" alt="스크린샷 2026-01-28 16 12 58" src="https://github.com/user-attachments/assets/b0eff6a2-b5de-4958-b70f-5c531fc3d2af" />
 
<img width="1024" height="910" alt="스크린샷 2026-01-28 16 13 05" src="https://github.com/user-attachments/assets/726aab0f-dc29-4242-918f-ce7de06b2e3b" />

## ✅ 체크리스트

- [ ] `Phase`에 맞는 이슈 체크리스트를 모두 완료했는가?
- [ ] lint / type-check 통과 및 불필요한 console.log 제거
- [ ] **머지 후 이 이슈가 [QA] 컬럼으로 이동함을 인지하고 있는가?**

## 워크로그
[2026-01-28_D2-1-worklog.md](https://github.com/user-attachments/files/24903324/2026-01-28_D2-1-worklog.md)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a grading results modal displaying exam overview statistics, student score rankings, and question-level performance metrics.
  * Modal includes summary statistics (exam date, average score, top 30% average, maximum score), student scores table with rankings, and per-question accuracy rates.
  * Modal can be opened from the student list sidebar.

* **Updates**
  * Updated student list sidebar to support new modal trigger functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->