### PR TITLE
feat: educators dashboard ui-only

### DIFF
--- a/src/app/(dashboard)/educators/_components/dashboard/DashboardClinicCard.tsx
+++ b/src/app/(dashboard)/educators/_components/dashboard/DashboardClinicCard.tsx
@@ -1,0 +1,45 @@
+import { ShieldCheck } from "lucide-react";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { DashboardClinicItem } from "@/types/dashboard";
+
+type DashboardClinicCardProps = {
+  clinics: DashboardClinicItem[];
+};
+
+export function DashboardClinicCard({ clinics }: DashboardClinicCardProps) {
+  return (
+    <Card className="shadow-sm">
+      <CardContent className="p-6">
+        <div className="flex items-center gap-2">
+          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-rose-100">
+            <ShieldCheck className="h-4 w-4 text-rose-600" />
+          </span>
+          <div>
+            <p className="text-sm font-semibold">클리닉</p>
+            <p className="text-xs text-muted-foreground">
+              예정된 클리닉 일정을 확인하세요
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-4 space-y-3">
+          {clinics.map((clinic) => (
+            <div
+              key={clinic.id}
+              className="rounded-lg border border-muted/60 bg-muted/20 px-4 py-3"
+            >
+              <p className="text-xs text-muted-foreground">{clinic.date}</p>
+              <p className="text-sm font-semibold text-foreground">
+                {clinic.title}
+              </p>
+              {clinic.meta ? (
+                <p className="text-xs text-muted-foreground">{clinic.meta}</p>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/educators/_components/dashboard/DashboardHeader.tsx
+++ b/src/app/(dashboard)/educators/_components/dashboard/DashboardHeader.tsx
@@ -1,0 +1,10 @@
+import { SectionHeader } from "@/components/common/SectionHeader";
+
+export function DashboardHeader() {
+  return (
+    <SectionHeader
+      title="강사/조교 대시보드"
+      description="오늘의 업무와 소통 현황을 한눈에 확인하세요."
+    />
+  );
+}

--- a/src/app/(dashboard)/educators/_components/dashboard/DashboardInquiryTable.tsx
+++ b/src/app/(dashboard)/educators/_components/dashboard/DashboardInquiryTable.tsx
@@ -1,0 +1,106 @@
+import { MessageSquare } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import { DashboardInquiry } from "@/types/dashboard";
+
+type DashboardInquiryTableProps = {
+  inquiries: DashboardInquiry[];
+};
+
+const typeBadgeClasses = {
+  학생: "bg-emerald-100 text-emerald-700",
+  학부모: "bg-sky-100 text-sky-700",
+} as const;
+
+const statusBadgeClasses = {
+  "진행 중": "bg-amber-100 text-amber-700",
+  대기: "bg-slate-100 text-slate-700",
+  완료: "bg-emerald-100 text-emerald-700",
+  "답변 완료": "bg-indigo-100 text-indigo-700",
+} as const;
+
+export function DashboardInquiryTable({
+  inquiries,
+}: DashboardInquiryTableProps) {
+  return (
+    <Card className="shadow-sm">
+      <CardContent className="p-6">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="flex h-8 w-8 items-center justify-center rounded-full bg-muted">
+              <MessageSquare className="h-4 w-4 text-muted-foreground" />
+            </span>
+            <div>
+              <p className="text-sm font-semibold">
+                최근 문의 요청 사항 (학생/학부모)
+              </p>
+              <p className="text-xs text-muted-foreground">
+                최근 문의 요청을 확인하세요
+              </p>
+            </div>
+          </div>
+          <Button variant="outline" className="h-8 px-3 text-xs" disabled>
+            전체보기
+          </Button>
+        </div>
+
+        <div className="mt-5">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[90px]">구분</TableHead>
+                <TableHead className="w-[120px]">이름</TableHead>
+                <TableHead>문의 내용</TableHead>
+                <TableHead className="w-[120px]">등록일</TableHead>
+                <TableHead className="w-[100px]">상태</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {inquiries.map((inquiry) => (
+                <TableRow key={inquiry.id}>
+                  <TableCell>
+                    <span
+                      className={cn(
+                        "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+                        typeBadgeClasses[inquiry.type]
+                      )}
+                    >
+                      {inquiry.type}
+                    </span>
+                  </TableCell>
+                  <TableCell className="font-medium">{inquiry.name}</TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {inquiry.message}
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {inquiry.createdAt}
+                  </TableCell>
+                  <TableCell>
+                    <span
+                      className={cn(
+                        "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+                        statusBadgeClasses[inquiry.status]
+                      )}
+                    >
+                      {inquiry.status}
+                    </span>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/educators/_components/dashboard/DashboardStatCards.tsx
+++ b/src/app/(dashboard)/educators/_components/dashboard/DashboardStatCards.tsx
@@ -1,0 +1,74 @@
+import { BookOpen, FileText, Users } from "lucide-react";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { DashboardStat } from "@/types/dashboard";
+
+type DashboardStatCardsProps = {
+  stats: DashboardStat[];
+};
+
+const statConfig = {
+  students: {
+    icon: Users,
+    cardClass: "border-emerald-100 bg-emerald-50/60",
+    iconClass: "text-emerald-600 bg-emerald-100",
+  },
+  lectures: {
+    icon: BookOpen,
+    cardClass: "border-sky-100 bg-sky-50/60",
+    iconClass: "text-sky-600 bg-sky-100",
+  },
+  exams: {
+    icon: FileText,
+    cardClass: "border-amber-100 bg-amber-50/60",
+    iconClass: "text-amber-600 bg-amber-100",
+  },
+} as const;
+
+export function DashboardStatCards({ stats }: DashboardStatCardsProps) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+      {stats.map((stat) => {
+        const config = statConfig[stat.key];
+        const Icon = config.icon;
+
+        return (
+          <Card
+            key={stat.id}
+            className={cn("min-h-[120px] shadow-sm", config.cardClass)}
+          >
+            <CardContent className="p-5">
+              <div className="flex items-start justify-between">
+                <div className="space-y-2">
+                  <p className="text-sm font-medium text-muted-foreground">
+                    {stat.label}
+                  </p>
+                  <div className="flex items-end gap-2">
+                    <span className="text-2xl font-semibold text-foreground lg:text-3xl">
+                      {stat.value}
+                    </span>
+                    <span className="text-sm text-muted-foreground">
+                      {stat.unit}
+                    </span>
+                  </div>
+                  {stat.note ? (
+                    <p className="text-xs text-muted-foreground">{stat.note}</p>
+                  ) : null}
+                </div>
+                <span
+                  className={cn(
+                    "flex h-9 w-9 items-center justify-center rounded-full",
+                    config.iconClass
+                  )}
+                >
+                  <Icon className="h-4 w-4" />
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/educators/_components/dashboard/DashboardTaskList.tsx
+++ b/src/app/(dashboard)/educators/_components/dashboard/DashboardTaskList.tsx
@@ -1,0 +1,78 @@
+import { ClipboardList } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { DashboardTask } from "@/types/dashboard";
+
+type DashboardTaskListProps = {
+  tasks: DashboardTask[];
+};
+
+const statusBadgeClasses = {
+  "진행 중": "bg-amber-100 text-amber-700",
+  대기: "bg-slate-100 text-slate-700",
+  완료: "bg-emerald-100 text-emerald-700",
+} as const;
+
+export function DashboardTaskList({ tasks }: DashboardTaskListProps) {
+  return (
+    <Card className="shadow-sm">
+      <CardContent className="p-6">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="flex h-8 w-8 items-center justify-center rounded-full bg-violet-100">
+              <ClipboardList className="h-4 w-4 text-violet-600" />
+            </span>
+            <div>
+              <p className="text-sm font-semibold">강사 업무 지시 내역</p>
+              <p className="text-xs text-muted-foreground">
+                조교 업무 진행률을 확인하세요
+              </p>
+            </div>
+          </div>
+          <Button variant="outline" className="h-8 px-3 text-xs" disabled>
+            업무내역
+          </Button>
+        </div>
+
+        <div className="mt-5 space-y-4">
+          {tasks.map((task) => (
+            <div
+              key={task.id}
+              className="rounded-lg border border-muted/60 bg-muted/20 p-4"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold">{task.title}</p>
+                  <p className="text-xs text-muted-foreground">{task.note}</p>
+                </div>
+                <span
+                  className={cn(
+                    "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+                    statusBadgeClasses[task.status]
+                  )}
+                >
+                  {task.status}
+                </span>
+              </div>
+              <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+                <span>대상 조교: {task.target}</span>
+                <span>{task.progress}%</span>
+              </div>
+              <div className="mt-2 h-2 w-full rounded-full bg-muted">
+                <div
+                  className={cn(
+                    "h-2 rounded-full",
+                    task.status === "완료" ? "bg-emerald-500" : "bg-violet-500"
+                  )}
+                  style={{ width: `${task.progress}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/educators/_components/dashboard/DashboardTodayScheduleCard.tsx
+++ b/src/app/(dashboard)/educators/_components/dashboard/DashboardTodayScheduleCard.tsx
@@ -1,0 +1,55 @@
+import { CalendarDays } from "lucide-react";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { DashboardScheduleItem } from "@/types/dashboard";
+
+type DashboardTodayScheduleCardProps = {
+  dateLabel: string;
+  items: DashboardScheduleItem[];
+};
+
+export function DashboardTodayScheduleCard({
+  dateLabel,
+  items,
+}: DashboardTodayScheduleCardProps) {
+  return (
+    <Card className="shadow-sm">
+      <CardContent className="p-6">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="flex h-8 w-8 items-center justify-center rounded-full bg-indigo-100">
+              <CalendarDays className="h-4 w-4 text-indigo-600" />
+            </span>
+            <div>
+              <p className="text-sm font-semibold">조교 담당 당일 수업</p>
+              <p className="text-xs text-muted-foreground">{dateLabel}</p>
+            </div>
+          </div>
+          <span className="text-xs text-muted-foreground">오늘</span>
+        </div>
+
+        <div className="mt-4 space-y-3">
+          {items.map((item) => (
+            <div
+              key={item.id}
+              className="flex items-start gap-4 rounded-lg border border-muted/60 bg-muted/20 px-4 py-3"
+            >
+              <div className="text-xs font-semibold text-muted-foreground">
+                <div>{item.startTime}</div>
+                <div>{item.endTime}</div>
+              </div>
+              <div>
+                <p className="text-sm font-semibold">{item.title}</p>
+                {item.subtitle ? (
+                  <p className="text-xs text-muted-foreground">
+                    {item.subtitle}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/educators/page.tsx
+++ b/src/app/(dashboard)/educators/page.tsx
@@ -1,24 +1,37 @@
-"use client";
+import {
+  mockDashboardClinics,
+  mockDashboardInquiries,
+  mockDashboardSchedule,
+  mockDashboardStats,
+  mockDashboardTasks,
+} from "@/data/dashboard.mock";
 
-import Link from "next/link";
-
-import { Button } from "@/components/ui/button";
-import { useAuth } from "@/hooks/useAuth";
+import { DashboardClinicCard } from "./_components/dashboard/DashboardClinicCard";
+import { DashboardHeader } from "./_components/dashboard/DashboardHeader";
+import { DashboardInquiryTable } from "./_components/dashboard/DashboardInquiryTable";
+import { DashboardStatCards } from "./_components/dashboard/DashboardStatCards";
+import { DashboardTaskList } from "./_components/dashboard/DashboardTaskList";
+import { DashboardTodayScheduleCard } from "./_components/dashboard/DashboardTodayScheduleCard";
 
 export default function EducatorsDashboardPage() {
-  const { signout } = useAuth();
   return (
-    <div>
-      <h1>EducatorsDashboardPage</h1>
-      <Button variant="outline" onClick={() => signout("MGMT")}>
-        Educator 로그아웃
-      </Button>
-      <Button variant="outline">
-        <Link href="/educators/lectures">수업 관리</Link>
-      </Button>
-      <Button variant="outline">
-        <Link href="/educators/students">학생 관리</Link>
-      </Button>
+    <div className="container mx-auto space-y-8 p-6">
+      <DashboardHeader />
+      <DashboardStatCards stats={mockDashboardStats} />
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px] 2xl:grid-cols-[minmax(0,1fr)_360px] xl:items-start">
+        <div className="space-y-6">
+          <DashboardInquiryTable inquiries={mockDashboardInquiries} />
+          <DashboardTaskList tasks={mockDashboardTasks} />
+        </div>
+        <div className="space-y-6">
+          <DashboardClinicCard clinics={mockDashboardClinics} />
+          <DashboardTodayScheduleCard
+            dateLabel="10월 25일"
+            items={mockDashboardSchedule}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/common/sidebar/AppSidebar.tsx
+++ b/src/components/common/sidebar/AppSidebar.tsx
@@ -10,6 +10,7 @@ import {
   Users,
   FileText,
   FolderOpen,
+  Home,
 } from "lucide-react";
 
 import {
@@ -26,6 +27,11 @@ import { useAuthContext } from "@/providers/AuthProvider";
 import { Role } from "@/types/auth.type";
 
 const instructorMenuItems = [
+  {
+    title: "홈",
+    url: "/educators",
+    icon: Home,
+  },
   {
     title: "학생 관리",
     url: "/educators/students",

--- a/src/data/dashboard.mock.ts
+++ b/src/data/dashboard.mock.ts
@@ -1,0 +1,125 @@
+import {
+  DashboardClinicItem,
+  DashboardInquiry,
+  DashboardScheduleItem,
+  DashboardStat,
+  DashboardTask,
+} from "@/types/dashboard";
+
+export const mockDashboardStats: DashboardStat[] = [
+  {
+    id: "stat-1",
+    key: "students",
+    label: "재원 학생",
+    value: 19,
+    unit: "명",
+    note: "추가 1명",
+  },
+  {
+    id: "stat-2",
+    key: "lectures",
+    label: "운영 중 수업",
+    value: 6,
+    unit: "개",
+    note: "신규 개설 1개",
+  },
+  {
+    id: "stat-3",
+    key: "exams",
+    label: "현재 시험 목록",
+    value: 3,
+    unit: "개",
+    note: "시험지 등록",
+  },
+];
+
+export const mockDashboardInquiries: DashboardInquiry[] = [
+  {
+    id: "inq-1",
+    type: "학생",
+    name: "김민준",
+    message: "고2 수학 A반 추가 상담 일정 문의",
+    createdAt: "10/12 14:00",
+    status: "진행 중",
+  },
+  {
+    id: "inq-2",
+    type: "학부모",
+    name: "김민준 학부모",
+    message: "고2 수학 A반 보충 수업 좌석 문의",
+    createdAt: "10/11 13:01",
+    status: "대기",
+  },
+  {
+    id: "inq-3",
+    type: "학생",
+    name: "박서연",
+    message: "고2 수학 A반 교재 환불 요청",
+    createdAt: "10/10 12:02",
+    status: "완료",
+  },
+  {
+    id: "inq-4",
+    type: "학부모",
+    name: "이준호 학부모",
+    message: "고2 수학 A반 시험 일정 문의",
+    createdAt: "10/09 11:03",
+    status: "답변 완료",
+  },
+];
+
+export const mockDashboardTasks: DashboardTask[] = [
+  {
+    id: "task-1",
+    title: "고2 수학 A반 업무 점검",
+    target: "김민수",
+    progress: 62,
+    status: "진행 중",
+    note: "리포트용 영어 모의평가 채점",
+  },
+  {
+    id: "task-2",
+    title: "고1 영어 B반 성적표 정리",
+    target: "이서준",
+    progress: 100,
+    status: "완료",
+    note: "성적표 발송 후 안내 메시지",
+  },
+];
+
+export const mockDashboardClinics: DashboardClinicItem[] = [
+  {
+    id: "clinic-1",
+    date: "1월 13일",
+    title: "[A반] 영어 듣기 평가 (30명)",
+  },
+  {
+    id: "clinic-2",
+    date: "1월 18일",
+    title: "[B반] 단어 테스트 (10명)",
+  },
+];
+
+export const mockDashboardSchedule: DashboardScheduleItem[] = [
+  {
+    id: "schedule-1",
+    startTime: "18:00",
+    endTime: "20:00",
+    title: "고2 수학 A반",
+    subtitle: "2관 304호",
+  },
+  {
+    id: "schedule-2",
+    startTime: "20:00",
+    endTime: "22:30",
+    title: "고3 파이널 대비반",
+    subtitle: "본관 502호",
+  },
+  {
+    id: "schedule-3",
+    startTime: "10:00",
+    endTime: "13:00",
+    title: "고1 수학 B반",
+    subtitle: "2관 201호",
+  },
+];

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,0 +1,48 @@
+export type DashboardStatKey = "students" | "lectures" | "exams";
+
+export type DashboardStat = {
+  id: string;
+  key: DashboardStatKey;
+  label: string;
+  value: number;
+  unit: string;
+  note?: string;
+};
+
+export type DashboardInquiryType = "학생" | "학부모";
+export type DashboardInquiryStatus = "진행 중" | "대기" | "완료" | "답변 완료";
+
+export type DashboardInquiry = {
+  id: string;
+  type: DashboardInquiryType;
+  name: string;
+  message: string;
+  createdAt: string;
+  status: DashboardInquiryStatus;
+};
+
+export type DashboardTaskStatus = "진행 중" | "대기" | "완료";
+
+export type DashboardTask = {
+  id: string;
+  title: string;
+  target: string;
+  progress: number;
+  status: DashboardTaskStatus;
+  note?: string;
+};
+
+export type DashboardClinicItem = {
+  id: string;
+  date: string;
+  title: string;
+  meta?: string;
+};
+
+export type DashboardScheduleItem = {
+  id: string;
+  startTime: string;
+  endTime: string;
+  title: string;
+  subtitle?: string;
+};


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #92 

## ✨ 작업 단계 및 변경 사항

- **작업 단계:** Phase 1: 디자인 및 API 연동 (UI-only)
- **변경 사항:**

      - 강사/조교 대시보드 UI-only 구성(요약 카드/문의/업무지시/클리닉/당일수업)
      - 대시보드 전용 컴포넌트/타입/Mock 데이터 분리
      - 사이드바에 홈 메뉴 추가 및 /educators 연결
      - 레이아웃 밀도 조정(사이드바 포함 기준 카드/컬럼 크기 최적화)

## 🧪 테스트 방법

리뷰어가 확인해야 할 핵심 포인트를 적어주세요.

  - [ ] /educators 대시보드 화면이 정상 렌더링되는가?
  - [ ] 카드/테이블/리스트 레이아웃이 사이드바 포함 상태에서 깨지지 않는가?
  - [ ] pnpm lint, pnpm type-check 통과하는가?

## 📸 스크린샷 (선택)
<img width="3083" height="1152" alt="스크린샷 2026-02-04 14 56 51" src="https://github.com/user-attachments/assets/33746c00-bb4a-4f87-8baa-c3b22f20a729" />


## ✅ 체크리스트

- [ ] `Phase`에 맞는 이슈 체크리스트를 모두 완료했는가?
- [ ] lint / type-check 통과 및 불필요한 console.log 제거
- [ ] **머지 후 이 이슈가 [QA] 컬럼으로 이동함을 인지하고 있는가?**

## 워크로그
[2026-02-04_Educators-Dashboard-worklog.md](https://github.com/user-attachments/files/25063413/2026-02-04_Educators-Dashboard-worklog.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive educator dashboard with key sections:
    * Statistics overview (students, lectures, exams)
    * Inquiry management table
    * Task list with progress tracking
    * Clinic information display
    * Today's schedule overview
  * Added home navigation link to educator sidebar

<!-- end of auto-generated comment: release notes by coderabbit.ai -->