### PR TITLE
fix: in_progress 상태이면서 0번 인덱스 기준 출결 등록 및 조회

### DIFF
--- a/src/app/(dashboard)/educators/students/[studentId]/page.tsx
+++ b/src/app/(dashboard)/educators/students/[studentId]/page.tsx
@@ -43,7 +43,7 @@ export default function StudentDetailPage() {
     isError: isDetailError,
   } = useEnrollmentDetail(studentId);
 
-  // SCHEDULED 상태인 강의들 1차 필터링
+  // IN_PROGRESS 상태인 강의들 1차 필터링
   const scheduledLectures =
     enrollmentData?.lectures?.filter(
       (lecture) => lecture.status === "IN_PROGRESS"


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #71 

## ✨ 작업 단계 및 변경 사항

- **작업 단계:** Phase 2: 디자인 및 API 연동
- **변경 사항:**
  - 학생 상세 페이지의 출결 등록 및 상세 출결 조회를 IN_PROGRESS 상태의 [0]번 인덱스 기준으로 변경

## 🧪 테스트 방법

리뷰어가 확인해야 할 핵심 포인트를 적어주세요.

- [ ] 개발자 도구에서 출결 등록, 조회가 어떤 강의 ID 기준으로 되는지 체크

## 📸 스크린샷 (선택)


## ✅ 체크리스트

- [ ] `Phase`에 맞는 이슈 체크리스트를 모두 완료했는가?
- [ ] lint / type-check 통과 및 불필요한 console.log 제거
- [ ] **머지 후 이 이슈가 [QA] 컬럼으로 이동함을 인지하고 있는가?**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved student dashboard attendance by selecting the active lecture only from in-progress lectures; dashboard now treats "no lecture" correctly and fetches attendance for the current in-progress lecture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->