### PR TITLE
feat: 강의 상태에 따라 학생 상세에 들어가지 못하는 문제 해결

### DIFF
--- a/src/app/(dashboard)/educators/students/[studentId]/page.tsx
+++ b/src/app/(dashboard)/educators/students/[studentId]/page.tsx
@@ -43,19 +43,19 @@ export default function StudentDetailPage() {
     isError: isDetailError,
   } = useEnrollmentDetail(studentId);
 
-  // IN_PROGRESS 상태인 강의들 1차 필터링
-  const scheduledLectures =
-    enrollmentData?.lectures?.filter(
-      (lecture) => lecture.status === "IN_PROGRESS"
-    ) || [];
+  // 전체 강의 목록 (상태 필터링 제거)
+  const allLectures = enrollmentData?.lectures || [];
 
-  // 필터링된 강의 중 가장 최신인 0번 인덱스 ID (출결 조회의 기준)
-  const mainLectureId = scheduledLectures[0]?.id;
+  // IN_PROGRESS 상태인 강의 중 가장 최신 강의 ID (출결 조회의 기준)
+  const inProgressLectures = allLectures.filter(
+    (lecture) => lecture.status === "IN_PROGRESS"
+  );
+  const mainLectureId = inProgressLectures[0]?.id;
 
-  // 수업이 있는지 확인
-  const hasNoLecture = !mainLectureId;
+  // 진행 중인 수업이 있는지 확인 (출결 등록 가능 여부)
+  const hasNoInProgressLecture = !mainLectureId;
 
-  // 학생 출결 통계 조회
+  // 학생 출결 통계 조회 (진행 중인 강의가 있을 때만)
   const {
     data: attendanceData,
     isPending: isAttendancePending,
@@ -66,14 +66,18 @@ export default function StudentDetailPage() {
   const attendancesList = attendanceData?.attendances || [];
   const enrolledLectures = enrollmentData?.lectures || [];
 
-  if (isDetailPending || isAttendancePending) {
+  if (isDetailPending || (isAttendancePending && !hasNoInProgressLecture)) {
     return (
       <div className="flex items-center justify-center h-screen">
         로딩 중...
       </div>
     );
   }
-  if (isDetailError || isAttendanceError || !enrollmentData) {
+  if (
+    isDetailError ||
+    (!hasNoInProgressLecture && isAttendanceError) ||
+    !enrollmentData
+  ) {
     return (
       <EmptyState
         message="학생 정보를 불러올 수 없습니다."
@@ -187,7 +191,7 @@ export default function StudentDetailPage() {
               </Button>
               <Button
                 className="cursor-pointer"
-                disabled={hasNoLecture}
+                disabled={hasNoInProgressLecture}
                 variant="default"
                 onClick={() =>
                   openModal(


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #이슈번호

## ✨ 작업 단계 및 변경 사항

- **작업 단계:** Phase 2: 디자인 및 API 연동
- **변경 사항:**
  - 강의 상태가 `IN_PROGRESS`일 때만 학생 상세 페이지 접근 가능한 오류 해결
  - 강의 상태 `SCHEDULE`, `IN_PROGRESS`, `COMPLETED`에 상관 없이 상세 페이지 접근 가능 

## 🧪 테스트 방법

리뷰어가 확인해야 할 핵심 포인트를 적어주세요.

- [ ] 강의 상태가 어떻든 학생 상세 페이지에 접근 가능한가?

## 📸 스크린샷 (선택)


## ✅ 체크리스트

- [ ] `Phase`에 맞는 이슈 체크리스트를 모두 완료했는가?
- [ ] lint / type-check 통과 및 불필요한 console.log 제거
- [ ] **머지 후 이 이슈가 [QA] 컬럼으로 이동함을 인지하고 있는가?**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attendance data handling by ensuring attendance registration features only activate when an in-progress lecture is available.
  * Enhanced error handling logic to properly display error states based on lecture and enrollment status.

* **Refactor**
  * Refined the logic for determining the active lecture to better reflect the application's lecture lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->