### PR TITLE
feat: 학생 목록 전체 인원수 고정 표시

### DIFF
--- a/src/app/(dashboard)/educators/students/page.tsx
+++ b/src/app/(dashboard)/educators/students/page.tsx
@@ -83,6 +83,7 @@ export default function StudentsListPage() {
 
   // 수강생 목록 조회 -> 검색할 때 query.keyword가 0.5초 뒤에 변경됨
   const { data, isPending, isError } = useEnrollmentList(query);
+
   const studentList = data?.list || [];
   const pagination: PaginationType = data?.pagination ?? {
     totalCount: 0,
@@ -92,6 +93,10 @@ export default function StudentsListPage() {
     hasNextPage: false,
     hasPrevPage: false,
   };
+
+  // 전체 인원 수 표시용
+  const { data: totalData } = useEnrollmentList({ page: 1, limit: 1 });
+  const ListTotalCount = totalData?.pagination?.totalCount ?? 0;
 
   // 수강생 재원 상태 수정
   const { mutate: updateStatus } = useUpdateEnrollment();
@@ -210,7 +215,7 @@ export default function StudentsListPage() {
     <div className="container mx-auto px-8 py-8 max-w-[1400px]">
       <Title
         title="전체 학생 관리"
-        description={`총 ${pagination.totalCount}명의 학생 정보를 관리하고 있습니다.`}
+        description={`총 ${ListTotalCount}명의 학생 정보를 관리하고 있습니다.`}
       />
 
       <StudentFilter


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #이슈번호

## ✨ 작업 단계 및 변경 사항

- **작업 단계:** Phase 2: 디자인 및 API 연동
- **변경 사항:**
  - 필터에 따라 변경되던 총 학생 인원수를 전체 인원수 고정으로 변경

## 🧪 테스트 방법

- [ ] 필터에 영향을 받지 않는 전체 학생 인원수 고정 체크

## 📸 스크린샷 (선택)

<img width="1558" height="393" alt="{5EE16CCC-54D1-427C-83DE-DD809627DB1A}" src="https://github.com/user-attachments/assets/478165e2-b3a9-452b-b87e-20f59f3211ed" />

- 데이터를 필터링 하더라도 강사가 관리하는 전체 인원수 표시는 고정됩니다.

## ✅ 체크리스트

- [ ] `Phase`에 맞는 이슈 체크리스트를 모두 완료했는가?
- [ ] lint / type-check 통과 및 불필요한 console.log 제거
- [ ] **머지 후 이 이슈가 [QA] 컬럼으로 이동함을 인지하고 있는가?**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected total student count display on the educators' students page to show the complete total rather than limiting to the current page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->