### PR TITLE
feat: 조교 관리 UI-only 플로우 개선 및 페이지 컴포넌트 분리

### DIFF
--- a/src/app/(dashboard)/educators/assistants/_components/AssistantsFiltersBar.tsx
+++ b/src/app/(dashboard)/educators/assistants/_components/AssistantsFiltersBar.tsx
@@ -1,0 +1,47 @@
+import { Search } from "lucide-react";
+
+import { type AssistantsListView } from "@/app/(dashboard)/educators/assistants/_types/assistants";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+type AssistantsFiltersBarProps = {
+  listView: AssistantsListView;
+  onChangeListView: (view: AssistantsListView) => void;
+};
+
+export default function AssistantsFiltersBar({
+  listView,
+  onChangeListView,
+}: AssistantsFiltersBarProps) {
+  return (
+    <Card>
+      <CardContent className="space-y-4 pt-6">
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="relative flex-1 min-w-[240px]">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input placeholder="조교 이름 또는 연락처 검색" className="pl-9" />
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant={listView === "active" ? "default" : "outline"}
+              className="rounded-full"
+              onClick={() => onChangeListView("active")}
+            >
+              재직
+            </Button>
+            <Button
+              type="button"
+              variant={listView === "retired" ? "default" : "outline"}
+              className="rounded-full"
+              onClick={() => onChangeListView("retired")}
+            >
+              퇴사
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/educators/assistants/_components/AssistantsHeader.tsx
+++ b/src/app/(dashboard)/educators/assistants/_components/AssistantsHeader.tsx
@@ -1,0 +1,48 @@
+import { CheckSquare } from "lucide-react";
+
+import AssistantsTabs, {
+  type AssistantsTabKey,
+} from "@/app/(dashboard)/educators/assistants/_components/AssistantsTabs";
+import Title from "@/components/common/header/Title";
+import { Button } from "@/components/ui/button";
+
+type AssistantsHeaderProps = {
+  activeTab: AssistantsTabKey;
+  onTabClick: (tab: AssistantsTabKey) => void;
+  onOpenTaskModal: () => void;
+  actionNotice: string | null;
+};
+
+export default function AssistantsHeader({
+  activeTab,
+  onTabClick,
+  onOpenTaskModal,
+  actionNotice,
+}: AssistantsHeaderProps) {
+  return (
+    <div className="space-y-6">
+      <Title
+        title="조교 관리"
+        description="배정된 조교를 조회하고 업무를 배정/평가합니다."
+      />
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <AssistantsTabs active={activeTab} onTabClick={onTabClick} />
+        <Button
+          variant="outline"
+          className="rounded-full"
+          onClick={onOpenTaskModal}
+        >
+          <CheckSquare className="mr-2 h-4 w-4" />
+          조교 업무 지시
+        </Button>
+      </div>
+
+      {actionNotice ? (
+        <div className="rounded-lg border bg-muted/40 px-4 py-3 text-sm text-muted-foreground">
+          {actionNotice}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/educators/assistants/_components/AssistantsStatsGrid.tsx
+++ b/src/app/(dashboard)/educators/assistants/_components/AssistantsStatsGrid.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+import type { LucideIcon } from "lucide-react";
+
+import { Card, CardContent } from "@/components/ui/card";
+
+type AssistantsStatItem = {
+  label: string;
+  value: string;
+  delta: string;
+  icon: LucideIcon;
+  accent: string;
+  href?: string;
+  modal?:
+    | "none"
+    | "task"
+    | "contractManage"
+    | "sendContract"
+    | "assistantDetail";
+};
+
+type AssistantsStatsGridProps = {
+  stats: AssistantsStatItem[];
+  onOpenContractManageModal: () => void;
+};
+
+export default function AssistantsStatsGrid({
+  stats,
+  onOpenContractManageModal,
+}: AssistantsStatsGridProps) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {stats.map((stat) => {
+        const Icon = stat.icon;
+        const isInteractive = Boolean(stat.href || stat.modal);
+        const card = (
+          <Card
+            className={
+              isInteractive
+                ? "transition hover:border-primary/40 hover:shadow-md"
+                : undefined
+            }
+          >
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-muted-foreground">{stat.label}</p>
+                  <p className="mt-2 text-3xl font-bold">{stat.value}</p>
+                  <p className={`mt-2 text-xs ${stat.accent}`}>{stat.delta}</p>
+                </div>
+                <div className="rounded-xl bg-muted p-3 text-muted-foreground">
+                  <Icon className="h-5 w-5" />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        );
+
+        if (stat.href) {
+          return (
+            <Link key={stat.label} href={stat.href} className="block">
+              {card}
+            </Link>
+          );
+        }
+
+        if (stat.modal === "contractManage") {
+          return (
+            <button
+              key={stat.label}
+              type="button"
+              className="block w-full text-left"
+              onClick={onOpenContractManageModal}
+            >
+              {card}
+            </button>
+          );
+        }
+
+        return <div key={stat.label}>{card}</div>;
+      })}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/educators/assistants/_components/AssistantsTable.tsx
+++ b/src/app/(dashboard)/educators/assistants/_components/AssistantsTable.tsx
@@ -1,0 +1,108 @@
+import {
+  type Assistant,
+  type AssistantsListView,
+  type AssistantsPagination,
+} from "@/app/(dashboard)/educators/assistants/_types/assistants";
+import StatusLabel from "@/components/common/label/StatusLabel";
+import { Pagination } from "@/components/common/pagination/Pagination";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Card, CardContent } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+type AssistantsTableProps = {
+  listView: AssistantsListView;
+  totalCount: number;
+  assistants: Assistant[];
+  statusColorMap: Record<Assistant["status"], "green" | "yellow" | "gray">;
+  pagination: AssistantsPagination;
+  onOpenAssistantDetail: (assistantId: string) => void;
+  onPageChange: (page: number) => void;
+};
+
+export default function AssistantsTable({
+  listView,
+  totalCount,
+  assistants,
+  statusColorMap,
+  pagination,
+  onOpenAssistantDetail,
+  onPageChange,
+}: AssistantsTableProps) {
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <span>
+            {listView === "active" ? "재직" : "퇴사"} 조교 {totalCount}명
+          </span>
+        </div>
+
+        <div className="mt-4 rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[50px]">
+                  <Checkbox />
+                </TableHead>
+                <TableHead>조교명</TableHead>
+                <TableHead>담당 과목</TableHead>
+                <TableHead>연락처</TableHead>
+                <TableHead>배정 클래스</TableHead>
+                <TableHead>최근 업무</TableHead>
+                <TableHead>상태</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {assistants.map((assistant) => (
+                <TableRow key={assistant.id}>
+                  <TableCell>
+                    <Checkbox />
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-3">
+                      <Avatar className="h-9 w-9">
+                        <AvatarFallback>
+                          {assistant.name.slice(0, 1)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <button
+                        type="button"
+                        className="font-medium text-primary underline-offset-2 hover:underline"
+                        onClick={() => onOpenAssistantDetail(assistant.id)}
+                      >
+                        {assistant.name}
+                      </button>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <span className="rounded-full bg-muted px-3 py-1 text-xs text-muted-foreground">
+                      {assistant.subject}
+                    </span>
+                  </TableCell>
+                  <TableCell>{assistant.phone}</TableCell>
+                  <TableCell>{assistant.className}</TableCell>
+                  <TableCell>{assistant.task}</TableCell>
+                  <TableCell>
+                    <StatusLabel color={statusColorMap[assistant.status]}>
+                      {assistant.status}
+                    </StatusLabel>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        <Pagination pagination={pagination} onPageChange={onPageChange} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/educators/assistants/_components/AssistantsTabs.tsx
+++ b/src/app/(dashboard)/educators/assistants/_components/AssistantsTabs.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+export type AssistantsTabKey = "manage" | "contracts" | "approval" | "history";
+
+type AssistantsTabsProps = {
+  active: AssistantsTabKey;
+  onTabClick?: (tab: AssistantsTabKey) => void;
+};
+
+const tabs: Array<{ key: AssistantsTabKey; label: string; href: string }> = [
+  { key: "manage", label: "조교 관리", href: "/educators/assistants" },
+  {
+    key: "contracts",
+    label: "계약서 관리",
+    href: "/educators/assistants",
+  },
+  {
+    key: "approval",
+    label: "조교 승인",
+    href: "/educators/assistants/approval",
+  },
+  {
+    key: "history",
+    label: "업무 지시 내역",
+    href: "/educators/assistants/history",
+  },
+];
+
+export default function AssistantsTabs({
+  active,
+  onTabClick,
+}: AssistantsTabsProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {tabs.map((tab) => {
+        if (tab.key === active) {
+          return (
+            <Button key={tab.key} className="rounded-full">
+              {tab.label}
+            </Button>
+          );
+        }
+
+        return onTabClick &&
+          (tab.key === "manage" || tab.key === "contracts") ? (
+          <Button
+            key={tab.key}
+            type="button"
+            variant="outline"
+            className="rounded-full"
+            onClick={() => onTabClick(tab.key)}
+          >
+            {tab.label}
+          </Button>
+        ) : (
+          <Button
+            key={tab.key}
+            asChild
+            variant="outline"
+            className="rounded-full"
+          >
+            <Link href={tab.href}>{tab.label}</Link>
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/educators/assistants/_modals/AssistantDetailModal.tsx
+++ b/src/app/(dashboard)/educators/assistants/_modals/AssistantDetailModal.tsx
@@ -1,0 +1,185 @@
+import { CheckSquare } from "lucide-react";
+
+import {
+  type Assistant,
+  type AssistantDetailDraft,
+  type AssistantStatus,
+} from "@/app/(dashboard)/educators/assistants/_types/assistants";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+type AssistantDetailModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectedAssistant: Assistant | undefined;
+  assistantDetailDraft: AssistantDetailDraft;
+  isEditingAssistantDetail: boolean;
+  editableStatusOptions: readonly ["근무전", "근무중"];
+  onChangeStatus: (status: AssistantStatus) => void;
+  onChangeMemo: (memo: string) => void;
+  onRetireAssistant: () => void;
+  onCancelEdit: () => void;
+  onSaveDetail: () => void;
+  onCloseDetail: () => void;
+  onStartEdit: () => void;
+};
+
+export default function AssistantDetailModal({
+  open,
+  onOpenChange,
+  selectedAssistant,
+  assistantDetailDraft,
+  isEditingAssistantDetail,
+  editableStatusOptions,
+  onChangeStatus,
+  onChangeMemo,
+  onRetireAssistant,
+  onCancelEdit,
+  onSaveDetail,
+  onCloseDetail,
+  onStartEdit,
+}: AssistantDetailModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto">
+        <DialogHeader className="text-left">
+          <div className="flex items-center gap-3">
+            <Avatar className="h-12 w-12">
+              <AvatarFallback>
+                {selectedAssistant?.name.slice(0, 1)}
+              </AvatarFallback>
+            </Avatar>
+            <div>
+              <DialogTitle className="text-2xl font-bold">
+                {selectedAssistant?.name}
+              </DialogTitle>
+              <DialogDescription className="mt-1 text-base">
+                현재 상태 {assistantDetailDraft.status}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <label className="text-sm font-semibold">이름</label>
+            <Input value={selectedAssistant?.name ?? ""} readOnly />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-semibold">연락처</label>
+            <Input value={selectedAssistant?.phone ?? ""} readOnly />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-semibold">이메일</label>
+            <Input value={selectedAssistant?.email ?? ""} readOnly />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-semibold">상태</label>
+            {isEditingAssistantDetail ? (
+              <Select
+                value={
+                  assistantDetailDraft.status === "퇴사"
+                    ? "근무중"
+                    : assistantDetailDraft.status
+                }
+                onValueChange={onChangeStatus}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {editableStatusOptions.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <Input value={assistantDetailDraft.status} readOnly />
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-semibold">메모</label>
+          <Textarea
+            value={assistantDetailDraft.memo}
+            readOnly={!isEditingAssistantDetail}
+            className="min-h-[100px]"
+            placeholder="조교 운영 메모를 입력하세요."
+            onChange={(event) => onChangeMemo(event.target.value)}
+          />
+        </div>
+
+        <DialogFooter className="gap-2">
+          {isEditingAssistantDetail ? (
+            <>
+              <Button
+                variant="outline"
+                className="rounded-full"
+                onClick={onRetireAssistant}
+                disabled={selectedAssistant?.status === "퇴사"}
+              >
+                퇴사 처리
+              </Button>
+              <Button
+                variant="outline"
+                className="rounded-full"
+                onClick={onCancelEdit}
+              >
+                취소
+              </Button>
+              <Button className="rounded-full" onClick={onSaveDetail}>
+                <CheckSquare className="h-4 w-4" />
+                저장
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                variant="outline"
+                className="rounded-full"
+                onClick={onCloseDetail}
+              >
+                닫기
+              </Button>
+              <Button
+                variant="outline"
+                className="rounded-full"
+                onClick={onRetireAssistant}
+                disabled={selectedAssistant?.status === "퇴사"}
+              >
+                퇴사 처리
+              </Button>
+              <Button
+                className="rounded-full"
+                disabled={selectedAssistant?.status === "퇴사"}
+                onClick={onStartEdit}
+              >
+                수정
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(dashboard)/educators/assistants/_modals/ContractManageModal.tsx
+++ b/src/app/(dashboard)/educators/assistants/_modals/ContractManageModal.tsx
@@ -1,0 +1,128 @@
+import { Download, FileUp, SendHorizontal } from "lucide-react";
+
+import {
+  type Assistant,
+  type ContractRecord,
+  type ContractStatus,
+} from "@/app/(dashboard)/educators/assistants/_types/assistants";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+type ContractManageModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  contractRecords: ContractRecord[];
+  assistantRecords: Assistant[];
+  contractStatusClassMap: Record<ContractStatus, string>;
+  onOpenContractSend: () => void;
+  onPreviewNotice: (message: string) => void;
+};
+
+export default function ContractManageModal({
+  open,
+  onOpenChange,
+  contractRecords,
+  assistantRecords,
+  contractStatusClassMap,
+  onOpenContractSend,
+  onPreviewNotice,
+}: ContractManageModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+        <DialogHeader className="text-left">
+          <div className="flex items-start justify-between gap-3 pr-8">
+            <div>
+              <DialogTitle className="text-lg font-bold sm:text-xl">
+                조교 계약서 관리
+              </DialogTitle>
+              <DialogDescription className="mt-1 text-sm sm:text-base">
+                서명 상태와 계약서 파일을 확인하고 관리합니다.
+              </DialogDescription>
+            </div>
+            <Button className="rounded-full" onClick={onOpenContractSend}>
+              <SendHorizontal className="h-4 w-4" />
+              계약서 발송
+            </Button>
+          </div>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          {contractRecords.map((contract) => {
+            const assistant = assistantRecords.find(
+              (item) => item.id === contract.assistantId
+            );
+            if (!assistant) {
+              return null;
+            }
+
+            return (
+              <div
+                key={contract.id}
+                className="rounded-xl border bg-muted/30 px-6 py-5"
+              >
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                  <div className="space-y-1.5">
+                    <p className="text-base font-semibold tracking-tight sm:text-lg">
+                      {assistant.name}
+                    </p>
+                    <p className="text-xs font-medium text-muted-foreground sm:text-sm">
+                      {assistant.subject} · {assistant.className}
+                    </p>
+                    <p className="text-xs text-muted-foreground sm:text-sm">
+                      업데이트: {contract.updatedAt}
+                    </p>
+                  </div>
+
+                  <div className="space-y-3 lg:text-right">
+                    <span
+                      className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold sm:text-sm ${contractStatusClassMap[contract.status]}`}
+                    >
+                      {contract.status}
+                    </span>
+                    <div>
+                      <Button
+                        variant="outline"
+                        className="rounded-full text-xs sm:text-sm"
+                      >
+                        <Download className="h-4 w-4" />
+                        {contract.fileName}
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button
+            variant="outline"
+            className="rounded-full"
+            onClick={() =>
+              onPreviewNotice("계약서 일괄 다운로드는 UI 미리보기 단계입니다.")
+            }
+          >
+            계약서 일괄 다운로드
+          </Button>
+          <Button
+            variant="outline"
+            className="rounded-full"
+            onClick={onOpenContractSend}
+          >
+            <FileUp className="h-4 w-4" />
+            계약서 업로드
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(dashboard)/educators/assistants/_modals/ContractSendModal.tsx
+++ b/src/app/(dashboard)/educators/assistants/_modals/ContractSendModal.tsx
@@ -1,0 +1,175 @@
+import { FileUp, Mail, SendHorizontal } from "lucide-react";
+
+import { type Assistant } from "@/app/(dashboard)/educators/assistants/_types/assistants";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type ContractSendModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  assistantRecords: Assistant[];
+  sendTargetId: string;
+  onChangeSendTargetId: (assistantId: string) => void;
+  selectedTargetAssistant: Assistant | undefined;
+  sendTemplate: string;
+  contractTemplateOptions: readonly string[];
+  onChangeSendTemplate: (template: string) => void;
+  uploadFileName: string;
+  onChangeUploadFileName: (fileName: string) => void;
+  onOpenContractManage: () => void;
+  onPreviewNotice: (message: string) => void;
+};
+
+export default function ContractSendModal({
+  open,
+  onOpenChange,
+  assistantRecords,
+  sendTargetId,
+  onChangeSendTargetId,
+  selectedTargetAssistant,
+  sendTemplate,
+  contractTemplateOptions,
+  onChangeSendTemplate,
+  uploadFileName,
+  onChangeUploadFileName,
+  onOpenContractManage,
+  onPreviewNotice,
+}: ContractSendModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto">
+        <DialogHeader className="text-left">
+          <div className="flex items-start justify-between gap-3 pr-8">
+            <div>
+              <DialogTitle className="text-2xl font-bold">
+                조교 계약서 발송
+              </DialogTitle>
+              <DialogDescription className="mt-1 text-base">
+                서명 상태와 계약서 파일을 확인하고 발송합니다.
+              </DialogDescription>
+            </div>
+            <Button className="rounded-full" onClick={onOpenContractManage}>
+              <SendHorizontal className="h-4 w-4" />
+              계약서 관리
+            </Button>
+          </div>
+        </DialogHeader>
+
+        <div className="rounded-lg border bg-muted/40 px-4 py-3 text-sm text-muted-foreground">
+          선택한 조교의 이메일로 계약서 양식을 발송합니다. 서명 완료 시 자동
+          저장되며, 전송 로그가 기록됩니다.
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <label className="text-sm font-semibold">계약서 발송 대상</label>
+            <Select value={sendTargetId} onValueChange={onChangeSendTargetId}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {assistantRecords.map((assistant) => (
+                  <SelectItem key={assistant.id} value={assistant.id}>
+                    {assistant.name} · {assistant.subject}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-semibold">수신 이메일</label>
+            <Input value={selectedTargetAssistant?.email ?? ""} readOnly />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-semibold">발송 양식</label>
+            <Select value={sendTemplate} onValueChange={onChangeSendTemplate}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {contractTemplateOptions.map((template) => (
+                  <SelectItem key={template} value={template}>
+                    {template}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-semibold">
+              계약서 템플릿 업로드
+            </label>
+            <label
+              htmlFor="contract-template-file"
+              className="flex cursor-pointer items-center gap-3 rounded-lg border border-dashed border-muted-foreground/40 bg-muted/30 px-4 py-3 text-sm text-muted-foreground"
+            >
+              <FileUp className="h-4 w-4" />
+              <span>{uploadFileName}</span>
+            </label>
+            <Input
+              id="contract-template-file"
+              type="file"
+              className="hidden"
+              onChange={(event) =>
+                onChangeUploadFileName(
+                  event.target.files?.[0]?.name ?? "선택된 파일 없음"
+                )
+              }
+            />
+            <p className="text-xs text-muted-foreground">
+              PDF 또는 DOC/DOCX 업로드 가능
+            </p>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-dashed border-muted-foreground/35 bg-muted/30 px-5 py-4">
+          <p className="text-sm font-semibold">이메일 미리보기</p>
+          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+            안녕하세요 {selectedTargetAssistant?.name}님,
+            <br />
+            {sendTemplate} 파일을 확인하시고 3일 이내에 서명 부탁드립니다. 서명
+            완료 시 자동으로 시스템에 반영됩니다.
+          </p>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button
+            variant="outline"
+            className="rounded-full"
+            onClick={onOpenContractManage}
+          >
+            취소
+          </Button>
+          <Button
+            className="rounded-full"
+            onClick={() => {
+              onPreviewNotice("계약서 발송은 UI 미리보기 단계입니다.");
+              onOpenContractManage();
+            }}
+          >
+            <Mail className="h-4 w-4" />
+            계약서 발송
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(dashboard)/educators/assistants/_modals/ResourceLibraryModal.tsx
+++ b/src/app/(dashboard)/educators/assistants/_modals/ResourceLibraryModal.tsx
@@ -1,0 +1,168 @@
+import { Search } from "lucide-react";
+
+import {
+  type ResourceLibraryItem,
+  type ResourceLibraryCategory,
+} from "@/app/(dashboard)/educators/assistants/_types/assistants";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type ResourceLibraryModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  resourceSearchKeyword: string;
+  onChangeResourceSearchKeyword: (keyword: string) => void;
+  resourceCategoryFilter: "전체" | ResourceLibraryCategory;
+  resourceCategoryOptions: readonly [
+    "전체",
+    "수업자료",
+    "평가자료",
+    "운영문서",
+  ];
+  onChangeResourceCategoryFilter: (
+    category: "전체" | ResourceLibraryCategory
+  ) => void;
+  filteredResourceLibraryItems: ResourceLibraryItem[];
+  libraryDraftResourceIds: string[];
+  onToggleDraftResourceSelection: (resourceId: string) => void;
+  onCancel: () => void;
+  onApply: () => void;
+};
+
+export default function ResourceLibraryModal({
+  open,
+  onOpenChange,
+  resourceSearchKeyword,
+  onChangeResourceSearchKeyword,
+  resourceCategoryFilter,
+  resourceCategoryOptions,
+  onChangeResourceCategoryFilter,
+  filteredResourceLibraryItems,
+  libraryDraftResourceIds,
+  onToggleDraftResourceSelection,
+  onCancel,
+  onApply,
+}: ResourceLibraryModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto">
+        <DialogHeader className="text-left">
+          <DialogTitle className="text-xl font-bold">
+            자료실 검색 및 첨부 선택
+          </DialogTitle>
+          <DialogDescription>
+            필요한 자료를 검색해 선택한 뒤 업무 지시에 첨부합니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3 md:grid-cols-[1fr_180px]">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={resourceSearchKeyword}
+              onChange={(event) =>
+                onChangeResourceSearchKeyword(event.target.value)
+              }
+              placeholder="자료명 또는 분류로 검색"
+              className="pl-9"
+            />
+          </div>
+          <Select
+            value={resourceCategoryFilter}
+            onValueChange={onChangeResourceCategoryFilter}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {resourceCategoryOptions.map((option) => (
+                <SelectItem key={option} value={option}>
+                  {option}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>검색 결과 {filteredResourceLibraryItems.length}건</span>
+          <span>선택 {libraryDraftResourceIds.length}건</span>
+        </div>
+
+        <div className="space-y-2 rounded-lg border bg-background p-2">
+          {filteredResourceLibraryItems.length === 0 ? (
+            <div className="rounded-md px-4 py-10 text-center text-sm text-muted-foreground">
+              검색 조건에 맞는 자료가 없습니다.
+            </div>
+          ) : (
+            filteredResourceLibraryItems.map((resource) => {
+              const checked = libraryDraftResourceIds.includes(resource.id);
+              return (
+                <div
+                  key={resource.id}
+                  role="button"
+                  tabIndex={0}
+                  aria-pressed={checked}
+                  className={`flex w-full items-start gap-3 rounded-md border px-4 py-3 text-left transition ${
+                    checked
+                      ? "border-primary/60 bg-primary/5"
+                      : "border-transparent hover:border-muted"
+                  }`}
+                  onClick={() => onToggleDraftResourceSelection(resource.id)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      onToggleDraftResourceSelection(resource.id);
+                    }
+                  }}
+                >
+                  <Checkbox
+                    checked={checked}
+                    className="pointer-events-none mt-0.5"
+                  />
+                  <div className="flex-1">
+                    <p className="text-sm font-medium">{resource.title}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {resource.category} · {resource.updatedAt} ·{" "}
+                      {resource.sizeLabel}
+                    </p>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            className="rounded-full"
+            onClick={onCancel}
+          >
+            취소
+          </Button>
+          <Button type="button" className="rounded-full" onClick={onApply}>
+            선택 자료 첨부 ({libraryDraftResourceIds.length})
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(dashboard)/educators/assistants/_modals/TaskCreateModal.tsx
+++ b/src/app/(dashboard)/educators/assistants/_modals/TaskCreateModal.tsx
@@ -1,0 +1,172 @@
+import { CheckSquare, ClipboardCheck, FileText } from "lucide-react";
+
+import { type ResourceLibraryItem } from "@/app/(dashboard)/educators/assistants/_types/assistants";
+import TiptapEditor from "@/components/common/editor/TiptapEditor";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+type TaskCreateModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  taskInstructionContent: string;
+  onChangeTaskInstructionContent: (content: string) => void;
+  attachedResources: ResourceLibraryItem[];
+  onOpenResourceLibraryModal: () => void;
+  onRemoveAttachedResource: (resourceId: string) => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+};
+
+export default function TaskCreateModal({
+  open,
+  onOpenChange,
+  taskInstructionContent,
+  onChangeTaskInstructionContent,
+  attachedResources,
+  onOpenResourceLibraryModal,
+  onRemoveAttachedResource,
+  onCancel,
+  onSubmit,
+}: TaskCreateModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+        <DialogHeader className="text-left">
+          <div className="flex items-center gap-3">
+            <div className="rounded-full bg-primary/10 p-2 text-primary">
+              <ClipboardCheck className="h-5 w-5" />
+            </div>
+            <div>
+              <DialogTitle className="text-xl font-bold">
+                새 업무 지시 등록
+              </DialogTitle>
+              <DialogDescription className="mt-1">
+                김민수 조교에게 업무를 전달합니다.
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="rounded-lg border bg-muted/40 px-4 py-3 text-xs text-muted-foreground">
+          업무 지시는 상세 모달 기준으로 저장되어 조교에게 즉시 전달됩니다.
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-sm font-semibold">대상 조교</p>
+          <div className="flex items-center gap-3 rounded-lg border bg-background px-4 py-3">
+            <Avatar className="h-10 w-10">
+              <AvatarFallback>김</AvatarFallback>
+            </Avatar>
+            <div>
+              <p className="text-sm font-semibold">김민수</p>
+              <p className="text-xs text-muted-foreground">010-1234-5678</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">지시자</label>
+            <Input placeholder="강사 담당자" />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">업무명</label>
+            <Input placeholder="예: 중등 2학년 1학기 기말고사 채점" />
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">우선순위</label>
+            <div className="flex flex-wrap gap-2">
+              <Button variant="secondary" className="rounded-full">
+                높음
+              </Button>
+              <Button className="rounded-full">보통</Button>
+              <Button variant="secondary" className="rounded-full">
+                낮음
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium">업무 내용</label>
+          <TiptapEditor
+            content={taskInstructionContent}
+            onChange={onChangeTaskInstructionContent}
+            placeholder="업무에 대한 상세한 내용을 입력해주세요."
+            className="min-h-[240px]"
+          />
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <label className="text-sm font-medium">첨부 자료</label>
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-full"
+              onClick={onOpenResourceLibraryModal}
+            >
+              자료실에서 선택
+            </Button>
+          </div>
+
+          {attachedResources.length === 0 ? (
+            <div className="rounded-lg border border-dashed bg-muted/20 px-4 py-5 text-sm text-muted-foreground">
+              선택된 자료가 없습니다. 자료실에서 검색 후 선택해 첨부하세요.
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {attachedResources.map((resource) => (
+                <div
+                  key={resource.id}
+                  className="flex items-center justify-between rounded-lg border bg-muted/20 px-4 py-3"
+                >
+                  <div className="flex items-center gap-3">
+                    <FileText className="h-4 w-4 text-muted-foreground" />
+                    <div>
+                      <p className="text-sm font-medium">{resource.title}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {resource.category} · {resource.updatedAt} ·{" "}
+                        {resource.sizeLabel}
+                      </p>
+                    </div>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="h-8 px-3 text-xs"
+                    onClick={() => onRemoveAttachedResource(resource.id)}
+                  >
+                    제거
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" className="rounded-full" onClick={onCancel}>
+            취소
+          </Button>
+          <Button className="rounded-full" onClick={onSubmit}>
+            <CheckSquare className="h-4 w-4" />
+            지시 등록
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(dashboard)/educators/assistants/_types/assistants.ts
+++ b/src/app/(dashboard)/educators/assistants/_types/assistants.ts
@@ -1,0 +1,214 @@
+export const editableStatusOptions = ["근무전", "근무중"] as const;
+
+export type AssistantStatus = (typeof editableStatusOptions)[number] | "퇴사";
+
+export type Assistant = {
+  id: string;
+  name: string;
+  email: string;
+  subject: string;
+  phone: string;
+  className: string;
+  task: string;
+  memo: string;
+  status: AssistantStatus;
+  badge: string;
+};
+
+export const assistants: Assistant[] = [
+  {
+    id: "1",
+    name: "김민수",
+    email: "minsu.kim@academy.com",
+    subject: "수학",
+    phone: "010-1234-5678",
+    className: "중2 수학 심화반",
+    task: "주간 테스트 채점",
+    memo: "오답 정리 리포트 제출 주기 확인 필요",
+    status: "근무중",
+    badge: "bg-emerald-400/20 text-emerald-200",
+  },
+  {
+    id: "2",
+    name: "이진은",
+    email: "jineun.lee@academy.com",
+    subject: "영어",
+    phone: "010-9876-5432",
+    className: "고1 영어 내신대비",
+    task: "단어 시험 감독",
+    memo: "학부모 문의 대응 기록 있음",
+    status: "근무중",
+    badge: "bg-emerald-400/20 text-emerald-200",
+  },
+  {
+    id: "3",
+    name: "박성호",
+    email: "sungho.park@academy.com",
+    subject: "과학",
+    phone: "010-5555-4444",
+    className: "초6 창의과학 실험",
+    task: "업무 배정 예정",
+    memo: "다음 학기 재계약 여부 확인 필요",
+    status: "퇴사",
+    badge: "bg-slate-500/20 text-slate-300",
+  },
+  {
+    id: "4",
+    name: "최유리",
+    email: "yuri.choi@academy.com",
+    subject: "국어",
+    phone: "010-1111-2222",
+    className: "중3 국어 문법특강",
+    task: "학생 상담",
+    memo: "토요일 보충수업 지원 가능",
+    status: "근무전",
+    badge: "bg-amber-300/20 text-amber-100",
+  },
+  {
+    id: "5",
+    name: "정우성",
+    email: "woosung.jung@academy.com",
+    subject: "과학",
+    phone: "010-3333-7777",
+    className: "고2 물리 개념완성",
+    task: "업무 배정 예정",
+    memo: "정기 미팅 후 역할 재배정 예정",
+    status: "퇴사",
+    badge: "bg-slate-500/20 text-slate-300",
+  },
+];
+
+export type AssistantDetailDraft = {
+  status: AssistantStatus;
+  memo: string;
+};
+
+export const createAssistantDetailDraft = (
+  assistant?: Assistant
+): AssistantDetailDraft => ({
+  status: assistant?.status ?? "근무중",
+  memo: assistant?.memo ?? "",
+});
+
+export const statusColorMap: Record<
+  AssistantStatus,
+  "green" | "yellow" | "gray"
+> = {
+  근무전: "yellow",
+  근무중: "green",
+  퇴사: "gray",
+};
+
+export type ContractStatus = "서명 완료" | "서명 대기" | "재전송 필요";
+
+export type ContractRecord = {
+  id: string;
+  assistantId: string;
+  updatedAt: string;
+  fileName: string;
+  status: ContractStatus;
+};
+
+export const contractRecords: ContractRecord[] = [
+  {
+    id: "contract-1",
+    assistantId: "1",
+    updatedAt: "2024-06-18",
+    fileName: "2024-1학기_김민수_계약서.pdf",
+    status: "서명 완료",
+  },
+  {
+    id: "contract-2",
+    assistantId: "2",
+    updatedAt: "2024-06-17",
+    fileName: "2024-1학기_이진은_계약서.pdf",
+    status: "서명 대기",
+  },
+  {
+    id: "contract-3",
+    assistantId: "3",
+    updatedAt: "2024-06-16",
+    fileName: "2024-1학기_박성호_계약서.pdf",
+    status: "재전송 필요",
+  },
+];
+
+export const contractStatusClassMap: Record<ContractStatus, string> = {
+  "서명 완료": "bg-emerald-100 text-emerald-700",
+  "서명 대기": "bg-amber-100 text-amber-700",
+  "재전송 필요": "bg-rose-100 text-rose-700",
+};
+
+export const contractTemplateOptions = [
+  "표준 근로계약서 (2024)",
+  "단기 근로계약서 (파트타임)",
+  "조교 계약 연장 양식",
+] as const;
+
+export type ResourceLibraryCategory = "수업자료" | "평가자료" | "운영문서";
+
+export type ResourceLibraryItem = {
+  id: string;
+  title: string;
+  category: ResourceLibraryCategory;
+  updatedAt: string;
+  sizeLabel: string;
+};
+
+export const resourceLibraryItems: ResourceLibraryItem[] = [
+  {
+    id: "resource-1",
+    title: "중2 수학 1학기 기말고사 채점 가이드.pdf",
+    category: "평가자료",
+    updatedAt: "2026-02-07",
+    sizeLabel: "1.3MB",
+  },
+  {
+    id: "resource-2",
+    title: "중2 수학 오답노트 템플릿.hwp",
+    category: "수업자료",
+    updatedAt: "2026-02-06",
+    sizeLabel: "842KB",
+  },
+  {
+    id: "resource-3",
+    title: "조교 업무 체크리스트_학기중.xlsx",
+    category: "운영문서",
+    updatedAt: "2026-02-04",
+    sizeLabel: "560KB",
+  },
+  {
+    id: "resource-4",
+    title: "고1 영어 단어 테스트 감독 매뉴얼.pdf",
+    category: "수업자료",
+    updatedAt: "2026-02-03",
+    sizeLabel: "2.1MB",
+  },
+  {
+    id: "resource-5",
+    title: "모의고사 감독 유의사항 안내문.docx",
+    category: "평가자료",
+    updatedAt: "2026-01-31",
+    sizeLabel: "390KB",
+  },
+];
+
+export const resourceCategoryOptions = [
+  "전체",
+  "수업자료",
+  "평가자료",
+  "운영문서",
+] as const;
+
+export const PAGE_LIMIT = 5;
+
+export type AssistantsListView = "active" | "retired";
+
+export type AssistantsPagination = {
+  totalCount: number;
+  totalPage: number;
+  currentPage: number;
+  limit: number;
+  hasNextPage: boolean;
+  hasPrevPage: boolean;
+};

--- a/src/app/(dashboard)/educators/assistants/approval/page.tsx
+++ b/src/app/(dashboard)/educators/assistants/approval/page.tsx
@@ -7,8 +7,9 @@ import {
   KeyRound,
   UserPlus,
 } from "lucide-react";
-import Link from "next/link";
+import { useMemo, useState } from "react";
 
+import AssistantsTabs from "@/app/(dashboard)/educators/assistants/_components/AssistantsTabs";
 import Title from "@/components/common/header/Title";
 import StatusLabel from "@/components/common/label/StatusLabel";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -21,14 +22,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useSetBreadcrumb } from "@/hooks/useBreadcrumb";
 
 const approvalCode = "UCBW-NPZ7";
 
-const approvalStats = [
-  { label: "승인 대기", count: 1, active: true },
-  { label: "승인 완료", count: 1, active: false },
-  { label: "반려됨", count: 1, active: false },
-];
+const approvalStats = ["승인 대기", "승인 완료", "반려됨"] as const;
+type ApprovalStatus = (typeof approvalStats)[number];
 
 const applications = [
   {
@@ -44,15 +43,26 @@ const applications = [
 ];
 
 export default function AssistantsApprovalPage() {
+  useSetBreadcrumb([{ label: "조교 승인" }]);
+
+  const [activeStatusFilter, setActiveStatusFilter] =
+    useState<ApprovalStatus>("승인 대기");
+  const [actionNotice, setActionNotice] = useState<string | null>(null);
+
+  const filteredApplications = useMemo(
+    () =>
+      applications.filter(
+        (application) => application.status === activeStatusFilter
+      ),
+    [activeStatusFilter]
+  );
+
   return (
     <div className="container mx-auto space-y-8 p-6">
       <Card>
         <CardContent className="space-y-6 pt-6">
-          <div className="flex flex-wrap items-start justify-between gap-6">
+          <div className="flex flex-wrap items-start justify-between gap-4">
             <div className="space-y-2">
-              <p className="text-xs text-muted-foreground">
-                설정 · 사용자 관리 · 조교 승인
-              </p>
               <Title
                 title="조교 가입 승인"
                 description="승인 대기 중인 조교들의 정보를 확인하고 처리하세요."
@@ -60,20 +70,36 @@ export default function AssistantsApprovalPage() {
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
-              <Button asChild variant="outline" className="rounded-full">
-                <Link href="/educators/assistants">조교 관리</Link>
-              </Button>
-              <Button className="rounded-full">조교 승인</Button>
-              <Button variant="outline" className="rounded-full">
+              <Button
+                variant="outline"
+                className="rounded-full"
+                onClick={() =>
+                  setActionNotice("인증 코드 생성은 UI 미리보기 단계입니다.")
+                }
+              >
                 <KeyRound className="h-4 w-4" />
                 인증 코드 생성
               </Button>
-              <Button variant="outline" className="rounded-full">
+              <Button
+                variant="outline"
+                className="rounded-full"
+                onClick={() =>
+                  setActionNotice("가입 링크 복사는 UI 미리보기 단계입니다.")
+                }
+              >
                 <Copy className="h-4 w-4" />
                 가입 링크 복사
               </Button>
             </div>
           </div>
+
+          <AssistantsTabs active="approval" />
+
+          {actionNotice ? (
+            <div className="rounded-lg border bg-muted/40 px-4 py-3 text-sm text-muted-foreground">
+              {actionNotice}
+            </div>
+          ) : null}
 
           <div className="inline-flex items-center gap-2 rounded-lg bg-muted px-3 py-2 text-xs text-muted-foreground">
             <KeyRound className="h-3 w-3" />
@@ -93,13 +119,18 @@ export default function AssistantsApprovalPage() {
           <div className="flex flex-wrap items-center gap-2">
             {approvalStats.map((stat) => (
               <Button
-                key={stat.label}
-                variant={stat.active ? "default" : "secondary"}
+                key={stat}
+                variant={stat === activeStatusFilter ? "default" : "secondary"}
                 className="rounded-full"
+                onClick={() => setActiveStatusFilter(stat)}
               >
-                {stat.label}
+                {stat}
                 <span className="ml-2 rounded-full bg-white/20 px-2 py-0.5 text-xs">
-                  {stat.count}
+                  {
+                    applications.filter(
+                      (application) => application.status === stat
+                    ).length
+                  }
                 </span>
               </Button>
             ))}
@@ -126,51 +157,75 @@ export default function AssistantsApprovalPage() {
           </div>
 
           <div className="space-y-3">
-            {applications.map((application) => (
-              <div
-                key={application.id}
-                className="flex flex-wrap items-center gap-4 rounded-lg border bg-background p-4"
-              >
-                <Avatar className="h-12 w-12">
-                  <AvatarFallback>
-                    {application.name.slice(0, 1)}
-                  </AvatarFallback>
-                </Avatar>
-
-                <div className="min-w-[200px] flex-1 space-y-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="font-semibold">{application.name}</span>
-                    <StatusLabel color="blue">{application.status}</StatusLabel>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    {application.phone} · {application.email}
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    신청일: {application.appliedAt}
-                  </p>
-                </div>
-
-                <div className="min-w-[160px] rounded-md border px-3 py-2 text-xs">
-                  <p className="text-muted-foreground">담당 강사</p>
-                  <p className="font-medium">{application.mentor}</p>
-                </div>
-
-                <div className="min-w-[160px] rounded-md border px-3 py-2 text-xs">
-                  <p className="text-muted-foreground">지원 역할</p>
-                  <p className="font-medium">{application.role}</p>
-                </div>
-
-                <div className="ml-auto flex flex-wrap gap-2">
-                  <Button variant="secondary" className="rounded-full">
-                    <CheckCircle2 className="h-4 w-4" />
-                    승인
-                  </Button>
-                  <Button variant="outline" className="rounded-full">
-                    반려
-                  </Button>
-                </div>
+            {filteredApplications.length === 0 ? (
+              <div className="rounded-lg border border-dashed bg-muted/20 px-4 py-8 text-center text-sm text-muted-foreground">
+                선택한 상태의 신청 내역이 없습니다.
               </div>
-            ))}
+            ) : (
+              filteredApplications.map((application) => (
+                <div
+                  key={application.id}
+                  className="flex flex-wrap items-center gap-4 rounded-lg border bg-background p-4"
+                >
+                  <Avatar className="h-12 w-12">
+                    <AvatarFallback>
+                      {application.name.slice(0, 1)}
+                    </AvatarFallback>
+                  </Avatar>
+
+                  <div className="min-w-[200px] flex-1 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-semibold">{application.name}</span>
+                      <StatusLabel color="blue">
+                        {application.status}
+                      </StatusLabel>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {application.phone} · {application.email}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      신청일: {application.appliedAt}
+                    </p>
+                  </div>
+
+                  <div className="min-w-[160px] rounded-md border px-3 py-2 text-xs">
+                    <p className="text-muted-foreground">담당 강사</p>
+                    <p className="font-medium">{application.mentor}</p>
+                  </div>
+
+                  <div className="min-w-[160px] rounded-md border px-3 py-2 text-xs">
+                    <p className="text-muted-foreground">지원 역할</p>
+                    <p className="font-medium">{application.role}</p>
+                  </div>
+
+                  <div className="ml-auto flex flex-wrap gap-2">
+                    <Button
+                      variant="secondary"
+                      className="rounded-full"
+                      onClick={() =>
+                        setActionNotice(
+                          `${application.name} 승인 처리는 UI 미리보기 단계입니다.`
+                        )
+                      }
+                    >
+                      <CheckCircle2 className="h-4 w-4" />
+                      승인
+                    </Button>
+                    <Button
+                      variant="outline"
+                      className="rounded-full"
+                      onClick={() =>
+                        setActionNotice(
+                          `${application.name} 반려 처리는 UI 미리보기 단계입니다.`
+                        )
+                      }
+                    >
+                      반려
+                    </Button>
+                  </div>
+                </div>
+              ))
+            )}
           </div>
         </CardContent>
       </Card>

--- a/src/app/(dashboard)/educators/assistants/history/page.tsx
+++ b/src/app/(dashboard)/educators/assistants/history/page.tsx
@@ -1,0 +1,595 @@
+"use client";
+
+import {
+  CalendarClock,
+  ClipboardCheck,
+  CheckCircle2,
+  ClipboardList,
+  ListFilter,
+  Search,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+
+import AssistantsTabs from "@/app/(dashboard)/educators/assistants/_components/AssistantsTabs";
+import Title from "@/components/common/header/Title";
+import StatusLabel from "@/components/common/label/StatusLabel";
+import { Pagination } from "@/components/common/pagination/Pagination";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useSetBreadcrumb } from "@/hooks/useBreadcrumb";
+
+type TaskStatus = "진행 중" | "완료" | "보류";
+type TaskPriority = "높음" | "보통" | "낮음";
+
+type InstructionTask = {
+  id: string;
+  title: string;
+  subtitle: string;
+  assistantName: string;
+  instructorName: string;
+  issuedAt: string;
+  dueAt: string;
+  priority: TaskPriority;
+  status: TaskStatus;
+  description: string;
+  attachmentCount: number;
+};
+
+const mockTasks: InstructionTask[] = [
+  {
+    id: "task-1",
+    title: "고2 수학 A반 업무 점검",
+    subtitle: "리포트용 영어 모의평가 채점",
+    assistantName: "김민수",
+    instructorName: "김지훈",
+    issuedAt: "2026-02-06 09:00",
+    dueAt: "2026-02-09 18:00",
+    priority: "높음",
+    status: "진행 중",
+    description:
+      "A반 모의평가 주관식 채점을 우선 진행하고, 오답률 상위 5문항에 대한 코멘트를 정리해주세요.",
+    attachmentCount: 2,
+  },
+  {
+    id: "task-2",
+    title: "고3 파이널 대비반 업무 점검",
+    subtitle: "영어 독해 기본 평가 채점",
+    assistantName: "이지은",
+    instructorName: "김지훈",
+    issuedAt: "2026-02-05 13:30",
+    dueAt: "2026-02-08 22:00",
+    priority: "보통",
+    status: "완료",
+    description:
+      "독해 기본 평가지 채점 완료 후 평균 점수와 오답 유형 3가지를 요약해 전달해주세요.",
+    attachmentCount: 1,
+  },
+  {
+    id: "task-3",
+    title: "고1 수학 B반 업무 점검",
+    subtitle: "영어 문법+듣기 종합 채점",
+    assistantName: "박성호",
+    instructorName: "최서연",
+    issuedAt: "2026-02-03 15:00",
+    dueAt: "2026-02-07 20:00",
+    priority: "낮음",
+    status: "진행 중",
+    description:
+      "종합 평가 채점 후 문법 파트 오답률 기준으로 보충 설명이 필요한 학생 목록을 정리해주세요.",
+    attachmentCount: 0,
+  },
+  {
+    id: "task-4",
+    title: "중3 국어 문법 특강 업무 정리",
+    subtitle: "과제 제출 현황 정리",
+    assistantName: "최유리",
+    instructorName: "최서연",
+    issuedAt: "2026-01-28 10:00",
+    dueAt: "2026-02-02 21:00",
+    priority: "보통",
+    status: "완료",
+    description:
+      "과제 제출 누락자 명단 및 피드백 필요 학생을 분류해서 전달해주세요.",
+    attachmentCount: 1,
+  },
+  {
+    id: "task-5",
+    title: "고2 물리 개념완성 업무 확인",
+    subtitle: "주간 실험 리포트 검수",
+    assistantName: "정우성",
+    instructorName: "김지훈",
+    issuedAt: "2026-01-23 11:00",
+    dueAt: "2026-01-29 18:00",
+    priority: "높음",
+    status: "보류",
+    description:
+      "실험 리포트 형식 오류 항목을 정리하고 재제출이 필요한 학생에게 가이드를 안내해주세요.",
+    attachmentCount: 3,
+  },
+  {
+    id: "task-6",
+    title: "중2 수학 심화반 학습 리포트",
+    subtitle: "오답 노트 업데이트",
+    assistantName: "김민수",
+    instructorName: "최서연",
+    issuedAt: "2026-01-18 16:30",
+    dueAt: "2026-01-24 20:00",
+    priority: "낮음",
+    status: "완료",
+    description:
+      "오답 노트 템플릿 기준으로 개별 학생 업데이트 내역을 정리해주세요.",
+    attachmentCount: 0,
+  },
+];
+
+const PAGE_LIMIT = 5;
+
+const statusOptions: Array<TaskStatus | "전체"> = [
+  "전체",
+  "진행 중",
+  "완료",
+  "보류",
+];
+const priorityOptions: Array<TaskPriority | "전체"> = [
+  "전체",
+  "높음",
+  "보통",
+  "낮음",
+];
+const periodOptions = ["최근 1개월", "최근 3개월", "전체"] as const;
+
+const statusColorMap: Record<TaskStatus, "blue" | "green" | "gray"> = {
+  "진행 중": "blue",
+  완료: "green",
+  보류: "gray",
+};
+
+const priorityClassMap: Record<TaskPriority, string> = {
+  높음: "bg-red-50 text-red-600",
+  보통: "bg-blue-50 text-blue-600",
+  낮음: "bg-gray-100 text-gray-600",
+};
+
+const priorityDetailLabelMap: Record<TaskPriority, string> = {
+  높음: "긴급",
+  보통: "보통",
+  낮음: "일반",
+};
+
+const priorityDetailClassMap: Record<TaskPriority, string> = {
+  높음: "bg-red-100 text-red-600",
+  보통: "bg-blue-100 text-blue-700",
+  낮음: "bg-slate-100 text-slate-600",
+};
+
+const now = new Date("2026-02-08T23:59:59");
+
+function getDateByPeriod(period: (typeof periodOptions)[number]) {
+  if (period === "전체") {
+    return null;
+  }
+
+  const base = new Date(now);
+  if (period === "최근 1개월") {
+    base.setMonth(base.getMonth() - 1);
+    return base;
+  }
+
+  base.setMonth(base.getMonth() - 3);
+  return base;
+}
+
+export default function AssistantsTaskHistoryPage() {
+  useSetBreadcrumb([{ label: "업무 지시 내역" }]);
+
+  const taskRecords = mockTasks;
+  const [currentPage, setCurrentPage] = useState(1);
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const [statusFilter, setStatusFilter] =
+    useState<(typeof statusOptions)[number]>("전체");
+  const [priorityFilter, setPriorityFilter] =
+    useState<(typeof priorityOptions)[number]>("전체");
+  const [periodFilter, setPeriodFilter] =
+    useState<(typeof periodOptions)[number]>("최근 1개월");
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+
+  const filteredTasks = useMemo(() => {
+    const lowerKeyword = searchKeyword.trim().toLowerCase();
+    const periodStartDate = getDateByPeriod(periodFilter);
+
+    return taskRecords.filter((task) => {
+      const keywordMatched =
+        lowerKeyword.length === 0 ||
+        task.title.toLowerCase().includes(lowerKeyword) ||
+        task.subtitle.toLowerCase().includes(lowerKeyword) ||
+        task.assistantName.toLowerCase().includes(lowerKeyword);
+
+      const statusMatched =
+        statusFilter === "전체" || task.status === statusFilter;
+      const priorityMatched =
+        priorityFilter === "전체" || task.priority === priorityFilter;
+
+      const issuedDate = new Date(task.issuedAt.replace(" ", "T"));
+      const periodMatched =
+        periodStartDate === null ||
+        (issuedDate >= periodStartDate && issuedDate <= now);
+
+      return (
+        keywordMatched && statusMatched && priorityMatched && periodMatched
+      );
+    });
+  }, [periodFilter, priorityFilter, searchKeyword, statusFilter, taskRecords]);
+
+  const totalCount = filteredTasks.length;
+  const totalPage = Math.max(1, Math.ceil(totalCount / PAGE_LIMIT));
+  const safeCurrentPage = Math.min(currentPage, totalPage);
+  const hasNextPage = safeCurrentPage < totalPage;
+  const hasPrevPage = safeCurrentPage > 1;
+
+  const paginatedTasks = useMemo(() => {
+    const startIndex = (safeCurrentPage - 1) * PAGE_LIMIT;
+    return filteredTasks.slice(startIndex, startIndex + PAGE_LIMIT);
+  }, [filteredTasks, safeCurrentPage]);
+
+  const selectedTask =
+    selectedTaskId === null
+      ? null
+      : (taskRecords.find((task) => task.id === selectedTaskId) ?? null);
+
+  const progressCount = taskRecords.filter(
+    (task) => task.status === "진행 중"
+  ).length;
+  const completedCount = taskRecords.filter(
+    (task) => task.status === "완료"
+  ).length;
+
+  const pagination = {
+    totalCount,
+    totalPage,
+    currentPage: safeCurrentPage,
+    limit: PAGE_LIMIT,
+    hasNextPage,
+    hasPrevPage,
+  };
+
+  const resetPagination = () => {
+    setCurrentPage(1);
+  };
+
+  return (
+    <div className="container mx-auto space-y-8 p-6">
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <Title
+            title="업무 지시 내역 관리"
+            description="조교에게 배정된 업무를 모니터링하고 진행 현황을 관리합니다."
+          />
+        </div>
+
+        <AssistantsTabs active="history" />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">전체 업무</p>
+                <p className="mt-2 text-3xl font-bold">{taskRecords.length}</p>
+                <p className="mt-2 text-xs text-emerald-500">+12%</p>
+              </div>
+              <div className="rounded-xl bg-muted p-3 text-muted-foreground">
+                <CalendarClock className="h-5 w-5" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">진행 중</p>
+                <p className="mt-2 text-3xl font-bold">{progressCount}</p>
+                <p className="mt-2 text-xs text-blue-500">+5%</p>
+              </div>
+              <div className="rounded-xl bg-muted p-3 text-muted-foreground">
+                <ClipboardList className="h-5 w-5" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">완료</p>
+                <p className="mt-2 text-3xl font-bold">{completedCount}</p>
+                <p className="mt-2 text-xs text-emerald-500">-2%</p>
+              </div>
+              <div className="rounded-xl bg-muted p-3 text-muted-foreground">
+                <CheckCircle2 className="h-5 w-5" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardContent className="space-y-4 pt-6">
+          <div className="flex flex-col gap-3 xl:flex-row xl:items-center">
+            <div className="relative flex-1 min-w-[240px]">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={searchKeyword}
+                onChange={(event) => {
+                  setSearchKeyword(event.target.value);
+                  resetPagination();
+                }}
+                placeholder="업무 제목 또는 조교 이름으로 검색"
+                className="pl-9"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:flex xl:flex-wrap">
+              <Select
+                value={statusFilter}
+                onValueChange={(value: (typeof statusOptions)[number]) => {
+                  setStatusFilter(value);
+                  resetPagination();
+                }}
+              >
+                <SelectTrigger className="w-full xl:w-[130px]">
+                  <SelectValue placeholder="상태" />
+                </SelectTrigger>
+                <SelectContent>
+                  {statusOptions.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      상태: {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Select
+                value={priorityFilter}
+                onValueChange={(value: (typeof priorityOptions)[number]) => {
+                  setPriorityFilter(value);
+                  resetPagination();
+                }}
+              >
+                <SelectTrigger className="w-full xl:w-[140px]">
+                  <SelectValue placeholder="우선순위" />
+                </SelectTrigger>
+                <SelectContent>
+                  {priorityOptions.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      우선순위: {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Select
+                value={periodFilter}
+                onValueChange={(value: (typeof periodOptions)[number]) => {
+                  setPeriodFilter(value);
+                  resetPagination();
+                }}
+              >
+                <SelectTrigger className="w-full xl:w-[150px]">
+                  <SelectValue placeholder="기간" />
+                </SelectTrigger>
+                <SelectContent>
+                  {periodOptions.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      기간: {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="text-xs text-muted-foreground">
+              읽기 전용 미리보기 화면입니다.
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-6">
+          <div className="mb-4 flex items-center gap-2 text-sm text-muted-foreground">
+            <ListFilter className="h-4 w-4" />
+            <span>총 {totalCount}건의 업무 내역</span>
+          </div>
+
+          <div className="rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>업무 제목</TableHead>
+                  <TableHead>담당 조교</TableHead>
+                  <TableHead>지시자</TableHead>
+                  <TableHead>지시 일자</TableHead>
+                  <TableHead>우선순위</TableHead>
+                  <TableHead>상태</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {paginatedTasks.length === 0 ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={6}
+                      className="py-10 text-center text-muted-foreground"
+                    >
+                      조건에 맞는 업무 내역이 없습니다.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  paginatedTasks.map((task) => (
+                    <TableRow key={task.id}>
+                      <TableCell>
+                        <div className="space-y-1">
+                          <button
+                            type="button"
+                            className="text-left text-sm font-semibold text-primary underline-offset-2 hover:underline"
+                            onClick={() => setSelectedTaskId(task.id)}
+                          >
+                            {task.title}
+                          </button>
+                          <p className="text-xs text-muted-foreground">
+                            {task.subtitle}
+                          </p>
+                        </div>
+                      </TableCell>
+                      <TableCell className="font-medium">
+                        {task.assistantName}
+                      </TableCell>
+                      <TableCell>{task.instructorName}</TableCell>
+                      <TableCell>{task.issuedAt}</TableCell>
+                      <TableCell>
+                        <span
+                          className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${priorityClassMap[task.priority]}`}
+                        >
+                          {task.priority}
+                        </span>
+                      </TableCell>
+                      <TableCell>
+                        <StatusLabel color={statusColorMap[task.status]}>
+                          {task.status}
+                        </StatusLabel>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          <Pagination pagination={pagination} onPageChange={setCurrentPage} />
+        </CardContent>
+      </Card>
+
+      <Dialog
+        open={selectedTask !== null}
+        onOpenChange={(open) => !open && setSelectedTaskId(null)}
+      >
+        {selectedTask ? (
+          <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+            <DialogHeader className="text-left">
+              <div className="flex items-center gap-3">
+                <span className="rounded-full bg-primary/10 p-2 text-primary">
+                  <ClipboardCheck className="h-5 w-5" />
+                </span>
+                <div>
+                  <DialogTitle className="text-xl font-bold">
+                    업무 상세 정보
+                  </DialogTitle>
+                  <DialogDescription className="mt-1">
+                    지시 일자 · {selectedTask.issuedAt}
+                  </DialogDescription>
+                </div>
+              </div>
+            </DialogHeader>
+
+            <div className="rounded-lg border bg-muted/40 px-4 py-4 text-sm">
+              <div className="mb-3">
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-bold ${priorityDetailClassMap[selectedTask.priority]}`}
+                >
+                  {priorityDetailLabelMap[selectedTask.priority]}
+                </span>
+              </div>
+              <p className="text-lg font-bold leading-tight">
+                {selectedTask.title}
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {selectedTask.subtitle}
+              </p>
+            </div>
+
+            <div className="space-y-5 text-sm">
+              <div className="grid gap-4 rounded-lg border bg-background px-4 py-4 sm:grid-cols-2">
+                <div>
+                  <p className="text-xs font-semibold text-muted-foreground">
+                    담당 조교
+                  </p>
+                  <p className="mt-1 text-sm font-semibold">
+                    {selectedTask.assistantName}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold text-muted-foreground">
+                    지시 일자
+                  </p>
+                  <p className="mt-1 text-sm font-semibold">
+                    {selectedTask.issuedAt}
+                  </p>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <p className="text-sm font-semibold">업무 내용</p>
+                <div className="rounded-lg border bg-background px-4 py-3 text-sm leading-relaxed">
+                  {selectedTask.description}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <p className="text-sm font-semibold">첨부파일</p>
+                <div className="rounded-lg border border-dashed border-muted-foreground/40 bg-muted/30 px-4 py-5 text-center text-sm text-muted-foreground">
+                  {selectedTask.attachmentCount > 0
+                    ? `연결된 첨부파일 ${selectedTask.attachmentCount}개`
+                    : "연결된 첨부파일이 없습니다."}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <p className="text-sm font-semibold">상태</p>
+                <StatusLabel color={statusColorMap[selectedTask.status]}>
+                  {selectedTask.status}
+                </StatusLabel>
+              </div>
+            </div>
+
+            <DialogFooter className="gap-2">
+              <Button
+                variant="outline"
+                className="rounded-full"
+                onClick={() => setSelectedTaskId(null)}
+              >
+                닫기
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        ) : null}
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/educators/assistants/page.tsx
+++ b/src/app/(dashboard)/educators/assistants/page.tsx
@@ -1,52 +1,50 @@
 "use client";
 
-import {
-  Briefcase,
-  CalendarCheck,
-  CheckSquare,
-  ClipboardCheck,
-  ClipboardList,
-  Paperclip,
-  Search,
-  Users,
-} from "lucide-react";
+import { Briefcase, CalendarCheck, ClipboardList, Users } from "lucide-react";
 import { useMemo, useState } from "react";
-import Link from "next/link";
 
-import Title from "@/components/common/header/Title";
-import StatusLabel from "@/components/common/label/StatusLabel";
-import { Pagination } from "@/components/common/pagination/Pagination";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
+import AssistantsFiltersBar from "@/app/(dashboard)/educators/assistants/_components/AssistantsFiltersBar";
+import AssistantsHeader from "@/app/(dashboard)/educators/assistants/_components/AssistantsHeader";
+import AssistantsStatsGrid from "@/app/(dashboard)/educators/assistants/_components/AssistantsStatsGrid";
+import AssistantsTable from "@/app/(dashboard)/educators/assistants/_components/AssistantsTable";
+import AssistantDetailModal from "@/app/(dashboard)/educators/assistants/_modals/AssistantDetailModal";
+import ContractManageModal from "@/app/(dashboard)/educators/assistants/_modals/ContractManageModal";
+import ContractSendModal from "@/app/(dashboard)/educators/assistants/_modals/ContractSendModal";
+import ResourceLibraryModal from "@/app/(dashboard)/educators/assistants/_modals/ResourceLibraryModal";
+import TaskCreateModal from "@/app/(dashboard)/educators/assistants/_modals/TaskCreateModal";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { Textarea } from "@/components/ui/textarea";
+  assistants,
+  type Assistant,
+  type AssistantDetailDraft,
+  contractRecords,
+  contractStatusClassMap,
+  contractTemplateOptions,
+  createAssistantDetailDraft,
+  editableStatusOptions,
+  PAGE_LIMIT,
+  resourceCategoryOptions,
+  resourceLibraryItems,
+  statusColorMap,
+  type AssistantsListView,
+} from "@/app/(dashboard)/educators/assistants/_types/assistants";
+import { useSetBreadcrumb } from "@/hooks/useBreadcrumb";
 
-const stats = [
+type AssistantsModalType =
+  | "none"
+  | "task"
+  | "contractManage"
+  | "sendContract"
+  | "assistantDetail";
+
+const stats: Array<{
+  label: string;
+  value: string;
+  delta: string;
+  icon: typeof Users;
+  accent: string;
+  href?: string;
+  modal?: AssistantsModalType;
+}> = [
   {
     label: "전체 배정 조교",
     value: "5",
@@ -67,6 +65,7 @@ const stats = [
     delta: "미제출 2건",
     icon: ClipboardList,
     accent: "text-amber-300",
+    modal: "contractManage",
   },
   {
     label: "업무 지시 내역",
@@ -74,355 +73,388 @@ const stats = [
     delta: "이번 주 +12건",
     icon: CalendarCheck,
     accent: "text-emerald-300",
+    href: "/educators/assistants/history",
   },
 ];
-
-const statusOptions = ["근무중", "휴가", "퇴사"] as const;
-
-type AssistantStatus = (typeof statusOptions)[number];
-
-type Assistant = {
-  id: string;
-  name: string;
-  subject: string;
-  phone: string;
-  className: string;
-  task: string;
-  status: AssistantStatus;
-  badge: string;
-};
-
-const assistants: Assistant[] = [
-  {
-    id: "1",
-    name: "김민수",
-    subject: "수학",
-    phone: "010-1234-5678",
-    className: "중2 수학 심화반",
-    task: "주간 테스트 채점",
-    status: "근무중",
-    badge: "bg-emerald-400/20 text-emerald-200",
-  },
-  {
-    id: "2",
-    name: "이진은",
-    subject: "영어",
-    phone: "010-9876-5432",
-    className: "고1 영어 내신대비",
-    task: "단어 시험 감독",
-    status: "근무중",
-    badge: "bg-emerald-400/20 text-emerald-200",
-  },
-  {
-    id: "3",
-    name: "박성호",
-    subject: "과학",
-    phone: "010-5555-4444",
-    className: "초6 창의과학 실험",
-    task: "업무 배정 예정",
-    status: "퇴사",
-    badge: "bg-slate-500/20 text-slate-300",
-  },
-  {
-    id: "4",
-    name: "최유리",
-    subject: "국어",
-    phone: "010-1111-2222",
-    className: "중3 국어 문법특강",
-    task: "학생 상담",
-    status: "휴가",
-    badge: "bg-amber-300/20 text-amber-100",
-  },
-  {
-    id: "5",
-    name: "정우성",
-    subject: "과학",
-    phone: "010-3333-7777",
-    className: "고2 물리 개념완성",
-    task: "업무 배정 예정",
-    status: "퇴사",
-    badge: "bg-slate-500/20 text-slate-300",
-  },
-];
-
-const statusColorMap: Record<AssistantStatus, "green" | "yellow" | "gray"> = {
-  근무중: "green",
-  휴가: "yellow",
-  퇴사: "gray",
-};
-
-const PAGE_LIMIT = 5;
 
 export default function AssistantsPage() {
+  useSetBreadcrumb([{ label: "조교 관리" }]);
+
+  const [assistantRecords, setAssistantRecords] =
+    useState<Assistant[]>(assistants);
+  const [assistantsListView, setAssistantsListView] =
+    useState<AssistantsListView>("active");
   const [currentPage, setCurrentPage] = useState(1);
-  const [isTaskModalOpen, setTaskModalOpen] = useState(false);
-  const totalCount = assistants.length;
+  const [activeModal, setActiveModal] = useState<AssistantsModalType>("none");
+  const [selectedAssistantId, setSelectedAssistantId] = useState(
+    assistants[0]?.id ?? ""
+  );
+  const [assistantDetailDraft, setAssistantDetailDraft] =
+    useState<AssistantDetailDraft>(() =>
+      createAssistantDetailDraft(assistants[0])
+    );
+  const [isEditingAssistantDetail, setIsEditingAssistantDetail] =
+    useState(false);
+  const [sendTargetId, setSendTargetId] = useState(
+    contractRecords[0]?.assistantId ?? assistants[0]?.id ?? ""
+  );
+  const [sendTemplate, setSendTemplate] = useState<
+    (typeof contractTemplateOptions)[number]
+  >(contractTemplateOptions[0]);
+  const [uploadFileName, setUploadFileName] = useState("선택된 파일 없음");
+  const [taskInstructionContent, setTaskInstructionContent] = useState("");
+  const [isResourceLibraryModalOpen, setResourceLibraryModalOpen] =
+    useState(false);
+  const [attachedResourceIds, setAttachedResourceIds] = useState<string[]>([]);
+  const [libraryDraftResourceIds, setLibraryDraftResourceIds] = useState<
+    string[]
+  >([]);
+  const [resourceSearchKeyword, setResourceSearchKeyword] = useState("");
+  const [resourceCategoryFilter, setResourceCategoryFilter] =
+    useState<(typeof resourceCategoryOptions)[number]>("전체");
+  const [actionNotice, setActionNotice] = useState<string | null>(null);
+  const filteredAssistants = useMemo(
+    () =>
+      assistantRecords.filter((assistant) =>
+        assistantsListView === "retired"
+          ? assistant.status === "퇴사"
+          : assistant.status !== "퇴사"
+      ),
+    [assistantRecords, assistantsListView]
+  );
+
+  const totalCount = filteredAssistants.length;
   const totalPage = Math.max(1, Math.ceil(totalCount / PAGE_LIMIT));
-  const hasNextPage = currentPage < totalPage;
-  const hasPrevPage = currentPage > 1;
+  const resolvedCurrentPage = Math.min(currentPage, totalPage);
+  const hasNextPage = resolvedCurrentPage < totalPage;
+  const hasPrevPage = resolvedCurrentPage > 1;
   const paginatedAssistants = useMemo(() => {
-    const startIndex = (currentPage - 1) * PAGE_LIMIT;
-    return assistants.slice(startIndex, startIndex + PAGE_LIMIT);
-  }, [currentPage]);
+    const startIndex = (resolvedCurrentPage - 1) * PAGE_LIMIT;
+    return filteredAssistants.slice(startIndex, startIndex + PAGE_LIMIT);
+  }, [filteredAssistants, resolvedCurrentPage]);
 
   const pagination = {
     totalCount,
     totalPage,
-    currentPage,
+    currentPage: resolvedCurrentPage,
     limit: PAGE_LIMIT,
     hasNextPage,
     hasPrevPage,
   };
 
+  const selectedAssistant =
+    assistantRecords.find(
+      (assistant) => assistant.id === selectedAssistantId
+    ) ?? assistantRecords[0];
+
+  const selectedTargetAssistant =
+    assistantRecords.find((assistant) => assistant.id === sendTargetId) ??
+    assistantRecords[0];
+
+  const attachedResources = useMemo(
+    () =>
+      resourceLibraryItems.filter((item) =>
+        attachedResourceIds.includes(item.id)
+      ),
+    [attachedResourceIds]
+  );
+
+  const filteredResourceLibraryItems = useMemo(() => {
+    const normalizedKeyword = resourceSearchKeyword.trim().toLowerCase();
+
+    return resourceLibraryItems.filter((resource) => {
+      const categoryMatched =
+        resourceCategoryFilter === "전체" ||
+        resource.category === resourceCategoryFilter;
+      const keywordMatched =
+        normalizedKeyword.length === 0 ||
+        resource.title.toLowerCase().includes(normalizedKeyword) ||
+        resource.category.toLowerCase().includes(normalizedKeyword);
+
+      return categoryMatched && keywordMatched;
+    });
+  }, [resourceCategoryFilter, resourceSearchKeyword]);
+
+  const openAssistantDetailModal = (assistantId: string) => {
+    const assistant = assistantRecords.find((item) => item.id === assistantId);
+    if (!assistant) {
+      return;
+    }
+
+    setSelectedAssistantId(assistant.id);
+    setAssistantDetailDraft(createAssistantDetailDraft(assistant));
+    setIsEditingAssistantDetail(false);
+    setActiveModal("assistantDetail");
+  };
+
+  const closeAssistantDetailModal = () => {
+    setIsEditingAssistantDetail(false);
+    setActiveModal("none");
+  };
+
+  const saveAssistantDetail = () => {
+    setAssistantRecords((prev) =>
+      prev.map((assistant) =>
+        assistant.id === selectedAssistantId
+          ? {
+              ...assistant,
+              status: assistantDetailDraft.status,
+              memo: assistantDetailDraft.memo,
+            }
+          : assistant
+      )
+    );
+    setIsEditingAssistantDetail(false);
+    setPreviewNotice("조교 상세 정보가 저장되었습니다. (UI-only)");
+  };
+
+  const retireAssistant = () => {
+    if (!selectedAssistant || selectedAssistant.status === "퇴사") {
+      return;
+    }
+
+    setAssistantRecords((prev) =>
+      prev.map((assistant) =>
+        assistant.id === selectedAssistant.id
+          ? {
+              ...assistant,
+              status: "퇴사",
+            }
+          : assistant
+      )
+    );
+    setAssistantsListView("retired");
+    setCurrentPage(1);
+    setIsEditingAssistantDetail(false);
+    setPreviewNotice(
+      `${selectedAssistant.name} 조교가 퇴사자로 이동되었습니다. (UI-only)`
+    );
+    closeAssistantDetailModal();
+  };
+
+  const openContractSendModal = () => {
+    setActiveModal("sendContract");
+  };
+
+  const openContractManageModal = () => {
+    setActiveModal("contractManage");
+  };
+
+  const setPreviewNotice = (message: string) => {
+    setActionNotice(message);
+  };
+
+  const openResourceLibraryModal = () => {
+    setLibraryDraftResourceIds(attachedResourceIds);
+    setResourceLibraryModalOpen(true);
+  };
+
+  const closeResourceLibraryModal = () => {
+    setResourceLibraryModalOpen(false);
+    setResourceSearchKeyword("");
+    setResourceCategoryFilter("전체");
+    setLibraryDraftResourceIds([]);
+  };
+
+  const toggleDraftResourceSelection = (resourceId: string) => {
+    setLibraryDraftResourceIds((prev) =>
+      prev.includes(resourceId)
+        ? prev.filter((id) => id !== resourceId)
+        : [...prev, resourceId]
+    );
+  };
+
+  const applyResourceSelection = () => {
+    setAttachedResourceIds(libraryDraftResourceIds);
+    setPreviewNotice(
+      `자료실 첨부 항목 ${libraryDraftResourceIds.length}건이 반영되었습니다. (UI-only)`
+    );
+    closeResourceLibraryModal();
+  };
+
+  const removeAttachedResource = (resourceId: string) => {
+    setAttachedResourceIds((prev) => prev.filter((id) => id !== resourceId));
+  };
+
+  const closeTaskModal = () => {
+    setTaskInstructionContent("");
+    setAttachedResourceIds([]);
+    setLibraryDraftResourceIds([]);
+    setResourceSearchKeyword("");
+    setResourceCategoryFilter("전체");
+    setResourceLibraryModalOpen(false);
+    setActiveModal("none");
+  };
+
   return (
     <div className="container mx-auto space-y-8 p-6">
-      <div className="space-y-6">
-        <Title
-          title="조교 관리"
-          description="배정된 조교를 조회하고 업무를 배정/평가합니다."
-        />
+      <AssistantsHeader
+        activeTab={
+          activeModal === "contractManage" || activeModal === "sendContract"
+            ? "contracts"
+            : "manage"
+        }
+        onTabClick={(tab) => {
+          if (tab === "contracts") {
+            openContractManageModal();
+            return;
+          }
 
-        <div className="flex flex-wrap items-center gap-2">
-          <Button asChild className="rounded-full">
-            <Link href="/educators/assistants">조교 관리</Link>
-          </Button>
-          <Button asChild variant="outline" className="rounded-full">
-            <Link href="/educators/assistants/approval">조교 승인</Link>
-          </Button>
-          <Button
-            className="rounded-full"
-            onClick={() => setTaskModalOpen(true)}
-          >
-            <CheckSquare className="mr-2 h-4 w-4" />
-            조교 업무 지시
-          </Button>
-        </div>
-      </div>
+          if (tab === "manage") {
+            setActiveModal("none");
+          }
+        }}
+        onOpenTaskModal={() => setActiveModal("task")}
+        actionNotice={actionNotice}
+      />
 
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        {stats.map((stat) => {
-          const Icon = stat.icon;
-          return (
-            <Card key={stat.label}>
-              <CardContent className="pt-6">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm text-muted-foreground">
-                      {stat.label}
-                    </p>
-                    <p className="mt-2 text-3xl font-bold">{stat.value}</p>
-                    <p className={`mt-2 text-xs ${stat.accent}`}>
-                      {stat.delta}
-                    </p>
-                  </div>
-                  <div className="rounded-xl bg-muted p-3 text-muted-foreground">
-                    <Icon className="h-5 w-5" />
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+      <AssistantsStatsGrid
+        stats={stats}
+        onOpenContractManageModal={openContractManageModal}
+      />
+
+      <AssistantsFiltersBar
+        listView={assistantsListView}
+        onChangeListView={(view) => {
+          setAssistantsListView(view);
+          setCurrentPage(1);
+        }}
+      />
+
+      <AssistantsTable
+        listView={assistantsListView}
+        totalCount={totalCount}
+        assistants={paginatedAssistants}
+        statusColorMap={statusColorMap}
+        pagination={pagination}
+        onOpenAssistantDetail={openAssistantDetailModal}
+        onPageChange={setCurrentPage}
+      />
+
+      <ContractManageModal
+        open={activeModal === "contractManage"}
+        onOpenChange={(open) => {
+          if (open) {
+            openContractManageModal();
+            return;
+          }
+
+          setActiveModal("none");
+        }}
+        contractRecords={contractRecords}
+        assistantRecords={assistantRecords}
+        contractStatusClassMap={contractStatusClassMap}
+        onOpenContractSend={openContractSendModal}
+        onPreviewNotice={setPreviewNotice}
+      />
+
+      <ContractSendModal
+        open={activeModal === "sendContract"}
+        onOpenChange={(open) => {
+          if (open) {
+            openContractSendModal();
+            return;
+          }
+
+          setActiveModal("none");
+        }}
+        assistantRecords={assistantRecords}
+        sendTargetId={sendTargetId}
+        onChangeSendTargetId={setSendTargetId}
+        selectedTargetAssistant={selectedTargetAssistant}
+        sendTemplate={sendTemplate}
+        contractTemplateOptions={contractTemplateOptions}
+        onChangeSendTemplate={(template) =>
+          setSendTemplate(template as (typeof contractTemplateOptions)[number])
+        }
+        uploadFileName={uploadFileName}
+        onChangeUploadFileName={setUploadFileName}
+        onOpenContractManage={openContractManageModal}
+        onPreviewNotice={setPreviewNotice}
+      />
+
+      <AssistantDetailModal
+        open={activeModal === "assistantDetail"}
+        onOpenChange={(open) => {
+          if (open) {
+            setActiveModal("assistantDetail");
+            return;
+          }
+
+          closeAssistantDetailModal();
+        }}
+        selectedAssistant={selectedAssistant}
+        assistantDetailDraft={assistantDetailDraft}
+        isEditingAssistantDetail={isEditingAssistantDetail}
+        editableStatusOptions={editableStatusOptions}
+        onChangeStatus={(status) =>
+          setAssistantDetailDraft((prev) => ({
+            ...prev,
+            status,
+          }))
+        }
+        onChangeMemo={(memo) =>
+          setAssistantDetailDraft((prev) => ({
+            ...prev,
+            memo,
+          }))
+        }
+        onRetireAssistant={retireAssistant}
+        onCancelEdit={() => {
+          setAssistantDetailDraft(
+            createAssistantDetailDraft(selectedAssistant)
           );
-        })}
-      </div>
+          setIsEditingAssistantDetail(false);
+        }}
+        onSaveDetail={saveAssistantDetail}
+        onCloseDetail={closeAssistantDetailModal}
+        onStartEdit={() => {
+          setAssistantDetailDraft(
+            createAssistantDetailDraft(selectedAssistant)
+          );
+          setIsEditingAssistantDetail(true);
+          setPreviewNotice("수정 모드가 활성화되었습니다.");
+        }}
+      />
 
-      <Card>
-        <CardContent className="space-y-4 pt-6">
-          <div className="flex flex-wrap items-center gap-4">
-            <div className="relative flex-1 min-w-[240px]">
-              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder="조교 이름 또는 연락처 검색"
-                className="pl-9"
-              />
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <TaskCreateModal
+        open={activeModal === "task"}
+        onOpenChange={(open) =>
+          open ? setActiveModal("task") : closeTaskModal()
+        }
+        taskInstructionContent={taskInstructionContent}
+        onChangeTaskInstructionContent={setTaskInstructionContent}
+        attachedResources={attachedResources}
+        onOpenResourceLibraryModal={openResourceLibraryModal}
+        onRemoveAttachedResource={removeAttachedResource}
+        onCancel={closeTaskModal}
+        onSubmit={() => {
+          setPreviewNotice("업무 지시 등록은 UI 미리보기 단계입니다.");
+          closeTaskModal();
+        }}
+      />
 
-      <Card>
-        <CardContent className="pt-6">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <span>총 {totalCount}명의 조교</span>
-          </div>
+      <ResourceLibraryModal
+        open={isResourceLibraryModalOpen}
+        onOpenChange={(open) => {
+          if (open) {
+            openResourceLibraryModal();
+            return;
+          }
 
-          <div className="mt-4 rounded-lg border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-[50px]">
-                    <Checkbox />
-                  </TableHead>
-                  <TableHead>조교명</TableHead>
-                  <TableHead>담당 과목</TableHead>
-                  <TableHead>연락처</TableHead>
-                  <TableHead>배정 클래스</TableHead>
-                  <TableHead>최근 업무</TableHead>
-                  <TableHead>상태</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {paginatedAssistants.map((assistant) => (
-                  <TableRow key={assistant.id}>
-                    <TableCell>
-                      <Checkbox />
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex items-center gap-3">
-                        <Avatar className="h-9 w-9">
-                          <AvatarFallback>
-                            {assistant.name.slice(0, 1)}
-                          </AvatarFallback>
-                        </Avatar>
-                        <span className="font-medium">{assistant.name}</span>
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <span className="rounded-full bg-muted px-3 py-1 text-xs text-muted-foreground">
-                        {assistant.subject}
-                      </span>
-                    </TableCell>
-                    <TableCell>{assistant.phone}</TableCell>
-                    <TableCell>{assistant.className}</TableCell>
-                    <TableCell>{assistant.task}</TableCell>
-                    <TableCell>
-                      <div className="flex items-center gap-3">
-                        <StatusLabel color={statusColorMap[assistant.status]}>
-                          {assistant.status}
-                        </StatusLabel>
-                        <Select defaultValue={assistant.status}>
-                          <SelectTrigger className="h-8 w-[96px] rounded-full text-xs">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {statusOptions.map((option) => (
-                              <SelectItem key={option} value={option}>
-                                {option}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-
-          <Pagination pagination={pagination} onPageChange={setCurrentPage} />
-        </CardContent>
-      </Card>
-
-      <Dialog open={isTaskModalOpen} onOpenChange={setTaskModalOpen}>
-        <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
-          <DialogHeader className="text-left">
-            <div className="flex items-center gap-3">
-              <div className="rounded-full bg-primary/10 p-2 text-primary">
-                <ClipboardCheck className="h-5 w-5" />
-              </div>
-              <div>
-                <DialogTitle className="text-xl font-bold">
-                  새 업무 지시 등록
-                </DialogTitle>
-                <DialogDescription className="mt-1">
-                  김민수 조교에게 업무를 전달합니다.
-                </DialogDescription>
-              </div>
-            </div>
-          </DialogHeader>
-
-          <div className="rounded-lg border bg-muted/40 px-4 py-3 text-xs text-muted-foreground">
-            업무 지시는 상세 모달 기준으로 저장되어 조교에게 즉시 전달됩니다.
-          </div>
-
-          <div className="space-y-2">
-            <p className="text-sm font-semibold">대상 조교</p>
-            <div className="flex items-center gap-3 rounded-lg border bg-background px-4 py-3">
-              <Avatar className="h-10 w-10">
-                <AvatarFallback>김</AvatarFallback>
-              </Avatar>
-              <div>
-                <p className="text-sm font-semibold">김민수</p>
-                <p className="text-xs text-muted-foreground">010-1234-5678</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <label className="text-sm font-medium">지시자</label>
-              <Input placeholder="강사 담당자" />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium">업무명</label>
-              <Input placeholder="예: 중등 2학년 1학기 기말고사 채점" />
-            </div>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <label className="text-sm font-medium">업무 분류/요약</label>
-              <Input placeholder="예: 고3 수능 기출 / 25문항" />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium">우선순위</label>
-              <div className="flex flex-wrap gap-2">
-                <Button variant="secondary" className="rounded-full">
-                  높음
-                </Button>
-                <Button className="rounded-full">보통</Button>
-                <Button variant="secondary" className="rounded-full">
-                  낮음
-                </Button>
-              </div>
-            </div>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <label className="text-sm font-medium">지시 일자</label>
-              <Input type="date" />
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <label className="text-sm font-medium">업무 내용</label>
-            <Textarea
-              placeholder="업무에 대한 상세한 내용을 입력해주세요."
-              className="min-h-[120px]"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <label className="text-sm font-medium">첨부파일</label>
-            <label
-              htmlFor="task-file"
-              className="flex cursor-pointer items-center justify-center gap-2 rounded-lg border border-dashed border-muted-foreground/40 bg-muted/30 px-4 py-6 text-sm text-muted-foreground"
-            >
-              <Paperclip className="h-4 w-4" />
-              파일 첨부 (PDF/JPG/PNG)
-            </label>
-            <Input id="task-file" type="file" className="hidden" />
-          </div>
-
-          <DialogFooter className="gap-2">
-            <Button
-              variant="outline"
-              className="rounded-full"
-              onClick={() => setTaskModalOpen(false)}
-            >
-              취소
-            </Button>
-            <Button
-              className="rounded-full"
-              onClick={() => setTaskModalOpen(false)}
-            >
-              <CheckSquare className="h-4 w-4" />
-              지시 등록
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          closeResourceLibraryModal();
+        }}
+        resourceSearchKeyword={resourceSearchKeyword}
+        onChangeResourceSearchKeyword={setResourceSearchKeyword}
+        resourceCategoryFilter={resourceCategoryFilter}
+        resourceCategoryOptions={resourceCategoryOptions}
+        onChangeResourceCategoryFilter={setResourceCategoryFilter}
+        filteredResourceLibraryItems={filteredResourceLibraryItems}
+        libraryDraftResourceIds={libraryDraftResourceIds}
+        onToggleDraftResourceSelection={toggleDraftResourceSelection}
+        onCancel={closeResourceLibraryModal}
+        onApply={applyResourceSelection}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #64 

## ✨ 작업 단계 및 변경 사항

- **작업 단계:**  
  - Phase 1: 기능 구현(UI-only) 완료  
  - Phase 2: 디자인 및 API 연동은 후속 PR에서 진행 예정
- **변경 사항:**
  - 조교 관리 페이지(` /educators/assistants `)를 조합 레이어로 정리하고 컴포넌트 분리
    - `_components`: `AssistantsHeader`, `AssistantsStatsGrid`, `AssistantsFiltersBar`, `AssistantsTable`
    - `_modals`: `ContractManageModal`, `ContractSendModal`, `AssistantDetailModal`, `TaskCreateModal`, `ResourceLibraryModal`
    - `_types/assistants.ts`로 타입/목데이터/상수 분리
  - 계약서 관리 모달 URL 쿼리(`?modal=contractManage`) 의존 제거, 상태 기반 모달 오픈으로 통일
  - 업무지시 등록 모달 UI 정리
    - 불필요 입력(`업무 분류/요약`, `지시 일자`, 기존 첨부파일 업로드) 제거
    - 업무내용 입력을 공통 `TiptapEditor`로 교체
    - 첨부 플로우를 `자료실 검색 -> 선택 -> 첨부`로 변경
  - 조교 상세 모달 정책 반영
    - 수정 가능 필드: `상태`, `메모`
    - 읽기 전용 필드: `이름`, `연락처`, `이메일`
    - `퇴사 처리` 버튼 분리 + 목록 `재직/퇴사` 분리 조회
    - 상태 옵션은 `근무전`, `근무중` 중심으로 정리
  - 콘솔 Hydration 에러 수정
    - `button` 중첩 구조 제거(`<button>` 안 `<Checkbox(button)>` 문제 해결)

## 🧪 테스트 방법

리뷰어가 확인해야 할 핵심 포인트를 적어주세요.

- [ ] `/educators/assistants` 진입 시 페이지가 정상 렌더링되는가?
- [ ] `계약서 관리` 탭/카드 클릭 시 모달이 열리고 URL에 `?modal=` 쿼리가 붙지 않는가?
- [ ] `조교 업무 지시` 모달에서 `자료실에서 선택` 흐름(검색/선택/첨부/제거)이 정상 동작하는가?
- [ ] `조교 상세` 모달에서 `이름/연락처/이메일`은 읽기 전용이고 `상태/메모`만 수정 가능한가?
- [ ] `퇴사 처리` 후 `퇴사` 뷰에서 대상 조교가 확인되는가?
- [ ] 브라우저 콘솔에 nested button/hydration 에러가 발생하지 않는가?

## 📸 스크린샷 (선택)
<img width="1124" height="789" alt="스크린샷 2026-02-08 20 56 26" src="https://github.com/user-attachments/assets/e65f034a-d61e-4a3d-a2ea-ee3cec12ad1c" />
<img width="966" height="1160" alt="스크린샷 2026-02-08 20 56 16" src="https://github.com/user-attachments/assets/c6dfab84-7443-44e5-a179-6cf2981e9bc6" />
<img width="2011" height="1155" alt="스크린샷 2026-02-08 20 56 04" src="https://github.com/user-attachments/assets/262fc589-897c-4fd9-9f62-264890ecdf13" />
<img width="1982" height="1048" alt="스크린샷 2026-02-08 20 55 49" src="https://github.com/user-attachments/assets/af0ddb24-3599-49b0-8c15-b3282492b2e8" />
<img width="1120" height="667" alt="스크린샷 2026-02-08 20 55 42" src="https://github.com/user-attachments/assets/a5fbed7e-821f-4313-812a-7252b24b7dce" />
<img width="960" height="704" alt="스크린샷 2026-02-08 20 55 37" src="https://github.com/user-attachments/assets/bfe035c3-6942-4c00-9780-4b36e8543768" />
<img width="1120" height="559" alt="스크린샷 2026-02-08 20 55 25" src="https://github.com/user-attachments/assets/df469324-dc66-41e7-9038-0139bb568038" />



## ✅ 체크리스트

- [ ] `Phase`에 맞는 이슈 체크리스트를 모두 완료했는가?
- [ ] lint / type-check 통과 및 불필요한 console.log 제거
- [ ] **머지 후 이 이슈가 [QA] 컬럼으로 이동함을 인지하고 있는가?**


## 워크로그
[2026-02-08_F2-page-ui-worklog.md](https://github.com/user-attachments/files/25161209/2026-02-08_F2-page-ui-worklog.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive assistant management dashboard with search and filter capabilities
  * Introduced ability to view, edit, and manage assistant details and status
  * Added contract management workflows including document sending and status tracking
  * Implemented task creation and assignment system for assistants
  * Added resource library for attaching course materials to tasks
  * Introduced task history tracking with filtering by status, priority, and date range

<!-- end of auto-generated comment: release notes by coderabbit.ai -->