### PR TITLE
feat: 스케줄 페이지 api 연결

### DIFF
--- a/src/app/(dashboard)/educators/schedules/_components/ScheduleCalendar.tsx
+++ b/src/app/(dashboard)/educators/schedules/_components/ScheduleCalendar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import {
   Calendar,
   Views,
@@ -15,7 +16,7 @@ import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
-import type { CalendarEvent } from "@/app/(dashboard)/educators/schedules/_hooks/useScheduleEvents";
+import type { ScheduleCalendarEvent } from "@/types/schedules";
 
 const locales = { ko };
 
@@ -32,7 +33,6 @@ const calendarMessages = {
   previous: "이전",
   next: "다음",
   month: "월",
-  week: "주",
   day: "일",
   date: "날짜",
   time: "시간",
@@ -43,9 +43,24 @@ const calendarMessages = {
 type ScheduleCalendarProps = {
   view: View;
   currentDate: Date;
-  events: CalendarEvent[];
+  events: ScheduleCalendarEvent[];
   onViewChange: (view: View) => void;
   onNavigate: (date: Date) => void;
+  onSelectEvent?: (event: ScheduleCalendarEvent) => void;
+};
+
+const getReadableTextColor = (hexColor: string) => {
+  const normalized = hexColor.replace("#", "");
+  if (normalized.length !== 6) {
+    return "#1f2937";
+  }
+
+  const r = Number.parseInt(normalized.slice(0, 2), 16);
+  const g = Number.parseInt(normalized.slice(2, 4), 16);
+  const b = Number.parseInt(normalized.slice(4, 6), 16);
+
+  const luminance = (r * 299 + g * 587 + b * 114) / 1000;
+  return luminance >= 160 ? "#1f2937" : "#ffffff";
 };
 
 function CalendarToolbar({
@@ -53,7 +68,7 @@ function CalendarToolbar({
   view,
   onNavigate,
   onView,
-}: ToolbarProps<CalendarEvent, object>) {
+}: ToolbarProps<ScheduleCalendarEvent, object>) {
   const label = format(date, "yyyy년 M월", { locale: ko });
 
   return (
@@ -90,10 +105,7 @@ function CalendarToolbar({
         </span>
       </div>
       <ButtonGroup className="rounded-lg border border-input bg-background p-1 shadow-sm">
-        {[
-          { label: "월별", value: Views.MONTH },
-          { label: "주별", value: Views.WEEK },
-        ].map((option) => (
+        {[{ label: "월별", value: Views.MONTH }].map((option) => (
           <Button
             key={option.value}
             type="button"
@@ -115,12 +127,13 @@ function CalendarToolbar({
   );
 }
 
-export function ScheduleCalendar({
+function ScheduleCalendarComponent({
   view,
   currentDate,
   events,
   onViewChange,
   onNavigate,
+  onSelectEvent,
 }: ScheduleCalendarProps) {
   return (
     <Card className="border-none shadow-none">
@@ -130,13 +143,14 @@ export function ScheduleCalendar({
           events={events}
           startAccessor="start"
           endAccessor="end"
-          views={[Views.MONTH, Views.WEEK]}
+          views={[Views.MONTH]}
           view={view}
           date={currentDate}
           onView={(nextView: View) => onViewChange(nextView)}
           onNavigate={(nextDate: Date) => onNavigate(nextDate)}
+          onSelectEvent={onSelectEvent}
           popup
-          tooltipAccessor={(event: CalendarEvent) =>
+          tooltipAccessor={(event: ScheduleCalendarEvent) =>
             event.description ?? event.title
           }
           dayPropGetter={(date: Date) => {
@@ -150,8 +164,12 @@ export function ScheduleCalendar({
               ),
             };
           }}
-          eventPropGetter={(event: CalendarEvent) => ({
-            className: `eduops-calendar-event eduops-calendar-event--${event.category}`,
+          eventPropGetter={(event: ScheduleCalendarEvent) => ({
+            className: "eduops-calendar-event",
+            style: {
+              backgroundColor: event.categoryColor,
+              color: getReadableTextColor(event.categoryColor),
+            },
           })}
           components={{
             toolbar: CalendarToolbar,
@@ -164,3 +182,6 @@ export function ScheduleCalendar({
     </Card>
   );
 }
+
+export const ScheduleCalendar = memo(ScheduleCalendarComponent);
+ScheduleCalendar.displayName = "ScheduleCalendar";

--- a/src/app/(dashboard)/educators/schedules/_components/ScheduleSidebar.tsx
+++ b/src/app/(dashboard)/educators/schedules/_components/ScheduleSidebar.tsx
@@ -1,43 +1,70 @@
 "use client";
 
+import { memo } from "react";
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
+import { Plus } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
-import { scheduleCategoryOptions } from "@/data/schedules.mock";
-import type { CalendarEvent } from "@/app/(dashboard)/educators/schedules/_hooks/useScheduleEvents";
-import type { ScheduleFilters } from "@/app/(dashboard)/educators/schedules/_hooks/useScheduleEvents";
+import type {
+  ScheduleCalendarEvent,
+  ScheduleCategoryOption,
+  ScheduleFilters,
+} from "@/types/schedules";
 
 type ScheduleSidebarProps = {
+  categories: ScheduleCategoryOption[];
   filters: ScheduleFilters;
   onFilterChange: (
     updater: ScheduleFilters | ((prev: ScheduleFilters) => ScheduleFilters)
   ) => void;
-  todayEvents: CalendarEvent[];
+  todayEvents: ScheduleCalendarEvent[];
+  onSelectTodayEvent: (event: ScheduleCalendarEvent) => void;
   categoryLabelMap: Record<string, string>;
+  isCategoryActionLocked: boolean;
+  onOpenCreateCategoryModal: () => void;
 };
 
-export function ScheduleSidebar({
+function ScheduleSidebarComponent({
+  categories,
   filters,
   onFilterChange,
   todayEvents,
+  onSelectTodayEvent,
   categoryLabelMap,
+  isCategoryActionLocked,
+  onOpenCreateCategoryModal,
 }: ScheduleSidebarProps) {
   return (
     <div className="space-y-6">
       <Card>
         <CardContent className="p-5 space-y-4">
-          <div>
-            <p className="text-sm font-semibold">일정 필터</p>
-            <p className="text-xs text-muted-foreground">
-              표시할 일정 유형을 선택하세요.
-            </p>
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-sm font-semibold">일정 필터</p>
+              <p className="text-xs text-muted-foreground">
+                표시할 일정 유형을 선택하세요.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="default"
+              className="h-8 w-8 p-0"
+              aria-label="분류 추가"
+              onClick={onOpenCreateCategoryModal}
+              disabled={isCategoryActionLocked}
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
           </div>
+
           <div className="space-y-3">
-            {scheduleCategoryOptions.map((option) => (
+            {categories.map((option) => (
               <label
-                key={option.value}
+                key={option.id}
                 className="flex items-center justify-between text-sm"
               >
                 <span className="flex items-center gap-2">
@@ -45,14 +72,14 @@ export function ScheduleSidebar({
                     className="h-2 w-2 rounded-full"
                     style={{ backgroundColor: option.color }}
                   />
-                  {option.label}
+                  {option.name}
                 </span>
                 <Checkbox
-                  checked={filters[option.value]}
+                  checked={filters[option.id] ?? true}
                   onCheckedChange={(checked) =>
                     onFilterChange((prev) => ({
                       ...prev,
-                      [option.value]: Boolean(checked),
+                      [option.id]: Boolean(checked),
                     }))
                   }
                 />
@@ -77,7 +104,12 @@ export function ScheduleSidebar({
               </p>
             ) : (
               todayEvents.map((event) => (
-                <div key={event.id} className="flex gap-3">
+                <button
+                  key={event.id}
+                  type="button"
+                  className="flex w-full gap-3 rounded-md text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onClick={() => onSelectTodayEvent(event)}
+                >
                   <div className="flex h-10 w-10 flex-col items-center justify-center rounded-lg bg-brand-25 text-brand-700">
                     <span className="text-[10px] font-semibold">
                       {format(event.start, "M월", { locale: ko })}
@@ -91,21 +123,20 @@ export function ScheduleSidebar({
                       {event.name}
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      {event.timeLabel} · {categoryLabelMap[event.category]}
+                      {event.timeLabel} ·{" "}
+                      {categoryLabelMap[event.categoryKey] ??
+                        event.categoryName}
                     </p>
                   </div>
-                </div>
+                </button>
               ))
             )}
           </div>
-          <button
-            type="button"
-            className="text-xs text-muted-foreground hover:text-foreground"
-          >
-            전체 일정 보기 →
-          </button>
         </CardContent>
       </Card>
     </div>
   );
 }
+
+export const ScheduleSidebar = memo(ScheduleSidebarComponent);
+ScheduleSidebar.displayName = "ScheduleSidebar";

--- a/src/app/(dashboard)/educators/schedules/_hooks/useScheduleEditor.ts
+++ b/src/app/(dashboard)/educators/schedules/_hooks/useScheduleEditor.ts
@@ -1,0 +1,298 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { format } from "date-fns";
+
+import {
+  mapScheduleFormToPayload,
+  mapScheduleFormToUpdatePayload,
+  OTHER_CATEGORY_KEY,
+} from "@/services/schedules/schedules.mapper";
+import {
+  createScheduleAPI,
+  deleteScheduleAPI,
+  updateScheduleAPI,
+} from "@/services/schedules/schedules.service";
+import type {
+  ScheduleCalendarEvent,
+  ScheduleFormState,
+  ScheduleModalMode,
+} from "@/types/schedules";
+
+const KST_TIMEZONE = "Asia/Seoul";
+
+const KST_FORM_DATE_TIME_FORMATTER = new Intl.DateTimeFormat("sv-SE", {
+  timeZone: KST_TIMEZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+
+const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "일정을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.";
+};
+
+const getKstFormDateTimeFromDate = (date: Date) => {
+  const parts = KST_FORM_DATE_TIME_FORMATTER.formatToParts(date);
+
+  const getPart = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value ?? "00";
+
+  return {
+    date: `${getPart("year")}-${getPart("month")}-${getPart("day")}`,
+    time: `${getPart("hour")}:${getPart("minute")}`,
+  };
+};
+
+const TIME_FORMAT_REGEX = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+const toMinutes = (time: string) => {
+  const [hours, minutes] = time.split(":").map(Number);
+  return hours * 60 + minutes;
+};
+
+type UseScheduleEditorParams = {
+  defaultCategoryId: string;
+  isCategoryActionInProgress: boolean;
+  loadSchedules: () => Promise<void>;
+  onFocusDate: (date: Date) => void;
+};
+
+export function useScheduleEditor({
+  defaultCategoryId,
+  isCategoryActionInProgress,
+  loadSchedules,
+  onFocusDate,
+}: UseScheduleEditorParams) {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [scheduleModalMode, setScheduleModalMode] =
+    useState<ScheduleModalMode>("create");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isScheduleCreating, setIsScheduleCreating] = useState(false);
+  const [isScheduleUpdating, setIsScheduleUpdating] = useState(false);
+  const [isScheduleDeleting, setIsScheduleDeleting] = useState(false);
+  const [editingScheduleId, setEditingScheduleId] = useState<string | null>(
+    null
+  );
+  const [formState, setFormState] = useState<ScheduleFormState>({
+    title: "",
+    date: format(new Date(), "yyyy-MM-dd"),
+    startTime: "",
+    endTime: "",
+    isAllDay: false,
+    categoryId: OTHER_CATEGORY_KEY,
+    description: "",
+  });
+
+  const resetScheduleForm = useCallback(() => {
+    setFormState({
+      title: "",
+      date: format(new Date(), "yyyy-MM-dd"),
+      startTime: "",
+      endTime: "",
+      isAllDay: false,
+      categoryId: defaultCategoryId,
+      description: "",
+    });
+  }, [defaultCategoryId]);
+
+  const openCreateScheduleModal = useCallback(() => {
+    setEditingScheduleId(null);
+    setScheduleModalMode("create");
+    setFormError(null);
+    resetScheduleForm();
+    setCreateOpen(true);
+  }, [resetScheduleForm]);
+
+  const closeCreateScheduleModal = useCallback(() => {
+    setCreateOpen(false);
+    setEditingScheduleId(null);
+    setScheduleModalMode("create");
+    setFormError(null);
+  }, []);
+
+  const handleStartScheduleEdit = useCallback(
+    (event: ScheduleCalendarEvent) => {
+      const { date, time: startTime } = getKstFormDateTimeFromDate(event.start);
+      const { time: endTime } = getKstFormDateTimeFromDate(event.end);
+
+      setEditingScheduleId(event.id);
+      setScheduleModalMode("view");
+      setFormError(null);
+      setFormState({
+        title: event.name,
+        date,
+        startTime: event.allDay ? "" : startTime,
+        endTime: event.allDay ? "" : endTime,
+        isAllDay: Boolean(event.allDay),
+        categoryId: event.categoryId ?? OTHER_CATEGORY_KEY,
+        description: event.description ?? "",
+      });
+      setCreateOpen(true);
+    },
+    []
+  );
+
+  const enableScheduleEdit = useCallback(() => {
+    setScheduleModalMode("edit");
+  }, []);
+
+  const handleCreateSubmit = useCallback(async () => {
+    if (
+      isScheduleCreating ||
+      isScheduleUpdating ||
+      isScheduleDeleting ||
+      isCategoryActionInProgress
+    ) {
+      return;
+    }
+
+    if (scheduleModalMode === "view") {
+      return;
+    }
+
+    if (scheduleModalMode === "edit" && !editingScheduleId) {
+      setFormError("수정할 일정을 찾을 수 없습니다. 다시 시도해 주세요.");
+      return;
+    }
+
+    if (
+      !formState.title.trim() ||
+      !formState.date ||
+      (!formState.isAllDay && (!formState.startTime || !formState.endTime))
+    ) {
+      setFormError(
+        formState.isAllDay
+          ? "일정 제목과 날짜를 모두 입력해 주세요."
+          : "일정 제목, 날짜, 시작시간, 종료시간을 모두 입력해 주세요."
+      );
+      return;
+    }
+
+    if (
+      !formState.isAllDay &&
+      (!TIME_FORMAT_REGEX.test(formState.startTime) ||
+        !TIME_FORMAT_REGEX.test(formState.endTime))
+    ) {
+      setFormError("시간은 HH:mm 형식으로 입력해 주세요.");
+      return;
+    }
+
+    if (
+      !formState.isAllDay &&
+      toMinutes(formState.endTime) < toMinutes(formState.startTime)
+    ) {
+      setFormError("종료시간은 시작시간보다 빠를 수 없습니다.");
+      return;
+    }
+
+    const nextDate = new Date(
+      `${formState.date}T${formState.isAllDay ? "00:00" : formState.startTime}:00+09:00`
+    );
+
+    try {
+      if (editingScheduleId) {
+        setIsScheduleUpdating(true);
+        await updateScheduleAPI(
+          editingScheduleId,
+          mapScheduleFormToUpdatePayload(formState)
+        );
+      } else {
+        setIsScheduleCreating(true);
+        await createScheduleAPI(mapScheduleFormToPayload(formState));
+      }
+
+      await loadSchedules();
+
+      if (!Number.isNaN(nextDate.getTime())) {
+        onFocusDate(nextDate);
+      }
+
+      closeCreateScheduleModal();
+      setEditingScheduleId(null);
+      resetScheduleForm();
+    } catch (error) {
+      setFormError(getErrorMessage(error));
+    } finally {
+      setIsScheduleCreating(false);
+      setIsScheduleUpdating(false);
+    }
+  }, [
+    closeCreateScheduleModal,
+    scheduleModalMode,
+    editingScheduleId,
+    formState,
+    isCategoryActionInProgress,
+    isScheduleCreating,
+    isScheduleDeleting,
+    isScheduleUpdating,
+    loadSchedules,
+    onFocusDate,
+    resetScheduleForm,
+  ]);
+
+  const handleDeleteSchedule = useCallback(async () => {
+    if (
+      scheduleModalMode !== "edit" ||
+      !editingScheduleId ||
+      isScheduleDeleting ||
+      isScheduleUpdating
+    ) {
+      return;
+    }
+
+    if (!confirm("이 일정을 삭제하시겠어요?")) {
+      return;
+    }
+
+    setIsScheduleDeleting(true);
+
+    try {
+      await deleteScheduleAPI(editingScheduleId);
+      await loadSchedules();
+      closeCreateScheduleModal();
+      setEditingScheduleId(null);
+      resetScheduleForm();
+    } catch (error) {
+      setFormError(getErrorMessage(error));
+    } finally {
+      setIsScheduleDeleting(false);
+    }
+  }, [
+    closeCreateScheduleModal,
+    scheduleModalMode,
+    editingScheduleId,
+    isScheduleDeleting,
+    isScheduleUpdating,
+    loadSchedules,
+    resetScheduleForm,
+  ]);
+
+  return {
+    createOpen,
+    scheduleModalMode,
+    editingScheduleId,
+    formError,
+    setFormError,
+    formState,
+    setFormState,
+    isScheduleCreating,
+    isScheduleUpdating,
+    isScheduleDeleting,
+    openCreateScheduleModal,
+    closeCreateScheduleModal,
+    handleStartScheduleEdit,
+    enableScheduleEdit,
+    handleCreateSubmit,
+    handleDeleteSchedule,
+    resetScheduleForm,
+  };
+}

--- a/src/app/(dashboard)/educators/schedules/_hooks/useScheduleEvents.ts
+++ b/src/app/(dashboard)/educators/schedules/_hooks/useScheduleEvents.ts
@@ -1,130 +1,593 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { View } from "react-big-calendar";
-import { format, isSameDay } from "date-fns";
+import { isSameDay } from "date-fns";
 
 import {
-  scheduleCategoryOptions,
-  scheduleSeeds,
-  type ScheduleCategory,
-} from "@/data/schedules.mock";
+  buildSchedulesRangeQuery,
+  mapScheduleApiToCalendarEvent,
+  normalizeScheduleCategories,
+  OTHER_CATEGORY_KEY,
+} from "@/services/schedules/schedules.mapper";
+import {
+  createScheduleCategoryAPI,
+  deleteScheduleCategoryAPI,
+  fetchScheduleCategoriesAPI,
+  fetchSchedulesAPI,
+  updateScheduleAPI,
+  updateScheduleCategoryAPI,
+} from "@/services/schedules/schedules.service";
+import { useScheduleEditor } from "@/app/(dashboard)/educators/schedules/_hooks/useScheduleEditor";
+import { useScheduleTimetable } from "@/app/(dashboard)/educators/schedules/_hooks/useScheduleTimetable";
+import type {
+  ScheduleApi,
+  ScheduleCalendarEvent,
+  ScheduleCategoryCreateState,
+  ScheduleCategoryEditState,
+  ScheduleCategoryOption,
+  ScheduleFilters,
+} from "@/types/schedules";
 
-export type CalendarEvent = {
-  id: string;
-  title: string;
-  name: string;
-  start: Date;
-  end: Date;
-  allDay?: boolean;
-  category: ScheduleCategory;
-  description?: string;
-  timeLabel: string;
+const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
+const DEFAULT_CATEGORY_COLOR = "#3863F6";
+
+const CATEGORY_MIGRATION_RANGE = {
+  startTime: "2000-01-01T00:00:00.000Z",
+  endTime: "2100-12-31T23:59:59.999Z",
 };
 
-const buildInitialEvents = (): CalendarEvent[] =>
-  scheduleSeeds.map((seed) => {
-    const start = new Date(`${seed.date}T${seed.time}:00`);
-    const displayTitle = `${seed.time} ${seed.title}`;
+const CATEGORY_MIGRATION_BATCH_SIZE = 8;
 
-    return {
-      id: seed.id,
-      title: displayTitle,
-      name: seed.title,
-      start,
-      end: start,
-      allDay: true,
-      category: seed.category,
-      description: seed.description,
-      timeLabel: seed.time,
-    };
+const syncFiltersWithCategories = (
+  prev: ScheduleFilters,
+  categories: ScheduleCategoryOption[]
+) => {
+  const next: ScheduleFilters = {};
+
+  categories.forEach((category) => {
+    next[category.id] = prev[category.id] ?? true;
   });
 
-export type ScheduleFormState = {
-  title: string;
-  date: string;
-  time: string;
-  category: ScheduleCategory;
-  description: string;
+  return next;
 };
 
-export type ScheduleFilters = Record<ScheduleCategory, boolean>;
+const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "일정을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.";
+};
+
+const getCategoryCreateErrorMessage = (error: unknown) => {
+  const normalizedError = error as {
+    response?: { data?: { message?: string } };
+    message?: string;
+  };
+
+  if (typeof normalizedError.response?.data?.message === "string") {
+    return normalizedError.response.data.message;
+  }
+
+  if (typeof normalizedError.message === "string" && normalizedError.message) {
+    return normalizedError.message;
+  }
+
+  return "카테고리 생성에 실패했습니다. 잠시 후 다시 시도해 주세요.";
+};
+
+const getCategoryActionErrorMessage = (error: unknown) => {
+  const normalizedError = error as {
+    response?: { data?: { message?: string } };
+    message?: string;
+  };
+
+  if (typeof normalizedError.response?.data?.message === "string") {
+    return normalizedError.response.data.message;
+  }
+
+  if (typeof normalizedError.message === "string" && normalizedError.message) {
+    return normalizedError.message;
+  }
+
+  return "카테고리 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.";
+};
+
+const migrateSchedulesToOtherCategory = async (
+  schedules: ScheduleApi[]
+): Promise<string[]> => {
+  const failedIds: string[] = [];
+
+  for (
+    let index = 0;
+    index < schedules.length;
+    index += CATEGORY_MIGRATION_BATCH_SIZE
+  ) {
+    const batch = schedules.slice(index, index + CATEGORY_MIGRATION_BATCH_SIZE);
+
+    const batchResults = await Promise.allSettled(
+      batch.map((schedule) => {
+        return updateScheduleAPI(schedule.id, {
+          categoryId: null,
+        });
+      })
+    );
+
+    batchResults.forEach((result, resultIndex) => {
+      if (result.status === "rejected") {
+        failedIds.push(batch[resultIndex].id);
+      }
+    });
+  }
+
+  return failedIds;
+};
 
 export function useScheduleEvents() {
-  const [events, setEvents] = useState<CalendarEvent[]>(() =>
-    buildInitialEvents()
-  );
+  const {
+    timetableOpen,
+    setTimetableOpen,
+    timetableEntries,
+    timetableMeta,
+    isTimetableLoading,
+    timetableError,
+  } = useScheduleTimetable();
+
+  const [events, setEvents] = useState<ScheduleCalendarEvent[]>([]);
+  const [categories, setCategories] = useState<ScheduleCategoryOption[]>([]);
   const [view, setView] = useState<View>("month");
   const [currentDate, setCurrentDate] = useState<Date>(new Date());
-  const [createOpen, setCreateOpen] = useState(false);
-  const [timetableOpen, setTimetableOpen] = useState(false);
-  const [formError, setFormError] = useState<string | null>(null);
-  const [formState, setFormState] = useState<ScheduleFormState>({
-    title: "",
-    date: "",
-    time: "",
-    category: "exam" as ScheduleCategory,
-    description: "",
-  });
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isSchedulesLoading, setIsSchedulesLoading] = useState(false);
+
+  const [isCategoryCreating, setIsCategoryCreating] = useState(false);
+  const [isCategoryUpdating, setIsCategoryUpdating] = useState(false);
+  const [isCategoryDeleting, setIsCategoryDeleting] = useState(false);
+  const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false);
+  const [deletingCategoryId, setDeletingCategoryId] = useState<string | null>(
+    null
+  );
+
+  const [categoryCreateState, setCategoryCreateState] =
+    useState<ScheduleCategoryCreateState>({
+      name: "",
+      color: DEFAULT_CATEGORY_COLOR,
+    });
+  const [categoryCreateError, setCategoryCreateError] = useState<string | null>(
+    null
+  );
+  const [editingCategoryId, setEditingCategoryId] = useState<string | null>(
+    null
+  );
+  const [categoryEditState, setCategoryEditState] =
+    useState<ScheduleCategoryEditState>({
+      name: "",
+      color: DEFAULT_CATEGORY_COLOR,
+    });
+  const [categoryUpdateError, setCategoryUpdateError] = useState<string | null>(
+    null
+  );
   const [filters, setFilters] = useState<ScheduleFilters>({
-    exam: true,
-    clinic: true,
-    misc: true,
+    [OTHER_CATEGORY_KEY]: true,
   });
+
+  const categoryMap = useMemo(
+    () => new Map(categories.map((category) => [category.id, category])),
+    [categories]
+  );
 
   const categoryLabelMap = useMemo(() => {
-    return scheduleCategoryOptions.reduce<Record<ScheduleCategory, string>>(
-      (acc, option) => {
-        acc[option.value] = option.label;
-        return acc;
-      },
-      {} as Record<ScheduleCategory, string>
-    );
-  }, []);
+    return categories.reduce<Record<string, string>>((acc, category) => {
+      acc[category.id] = category.name;
+      return acc;
+    }, {});
+  }, [categories]);
 
   const filteredEvents = useMemo(
-    () => events.filter((event) => filters[event.category]),
+    () =>
+      events.filter(
+        (event) =>
+          filters[event.categoryKey] ?? filters[OTHER_CATEGORY_KEY] ?? true
+      ),
     [events, filters]
   );
 
   const todayEvents = useMemo(() => {
     const today = new Date();
+
     return filteredEvents
       .filter((event) => isSameDay(event.start, today))
       .sort((a, b) => a.start.getTime() - b.start.getTime());
   }, [filteredEvents]);
 
-  const handleCreateSubmit = () => {
-    if (!formState.title || !formState.date || !formState.time) {
-      setFormError("일정 제목, 날짜, 시간을 모두 입력해 주세요.");
+  const loadSchedules = useCallback(async () => {
+    setIsSchedulesLoading(true);
+
+    try {
+      const query = buildSchedulesRangeQuery(currentDate, view);
+      const schedules = await fetchSchedulesAPI(query);
+
+      const mappedEvents = schedules
+        .map((schedule) => mapScheduleApiToCalendarEvent(schedule, categoryMap))
+        .filter((event): event is ScheduleCalendarEvent => event !== null);
+
+      setEvents(mappedEvents);
+      setLoadError(null);
+    } catch (error) {
+      setEvents([]);
+      setLoadError(getErrorMessage(error));
+    } finally {
+      setIsSchedulesLoading(false);
+    }
+  }, [categoryMap, currentDate, view]);
+
+  const defaultCategoryId = useMemo(() => {
+    return categories[0]?.id ?? OTHER_CATEGORY_KEY;
+  }, [categories]);
+
+  const {
+    createOpen,
+    scheduleModalMode,
+    editingScheduleId,
+    formError,
+    setFormError,
+    formState,
+    setFormState,
+    isScheduleCreating,
+    isScheduleUpdating,
+    isScheduleDeleting,
+    openCreateScheduleModal,
+    closeCreateScheduleModal,
+    handleStartScheduleEdit,
+    enableScheduleEdit,
+    handleCreateSubmit,
+    handleDeleteSchedule,
+  } = useScheduleEditor({
+    defaultCategoryId,
+    isCategoryActionInProgress:
+      isCategoryCreating || isCategoryUpdating || isCategoryDeleting,
+    loadSchedules,
+    onFocusDate: setCurrentDate,
+  });
+
+  const loadCategories = useCallback(async () => {
+    try {
+      const apiCategories = await fetchScheduleCategoriesAPI();
+      const normalizedCategories = normalizeScheduleCategories(apiCategories);
+
+      setCategories(normalizedCategories);
+      setFilters((prev) =>
+        syncFiltersWithCategories(prev, normalizedCategories)
+      );
+      setFormState((prev) => ({
+        ...prev,
+        categoryId: normalizedCategories.some(
+          (category) => category.id === prev.categoryId
+        )
+          ? prev.categoryId
+          : (normalizedCategories[0]?.id ?? OTHER_CATEGORY_KEY),
+      }));
+    } catch {
+      const fallbackCategories: ScheduleCategoryOption[] = [
+        {
+          id: OTHER_CATEGORY_KEY,
+          name: "기타",
+          color: "#f59e0b",
+        },
+      ];
+
+      setCategories(fallbackCategories);
+      setFilters((prev) => syncFiltersWithCategories(prev, fallbackCategories));
+      setFormState((prev) => ({
+        ...prev,
+        categoryId: fallbackCategories[0].id,
+      }));
+    }
+  }, [setFormState]);
+
+  useEffect(() => {
+    void loadCategories();
+  }, [loadCategories]);
+
+  useEffect(() => {
+    void loadSchedules();
+  }, [loadSchedules]);
+
+  const handleCreateCategory = useCallback(async () => {
+    if (
+      isCategoryCreating ||
+      isCategoryUpdating ||
+      isCategoryDeleting ||
+      isScheduleCreating ||
+      isScheduleUpdating ||
+      isScheduleDeleting
+    ) {
       return;
     }
 
-    const start = new Date(`${formState.date}T${formState.time}:00`);
-    const newEvent: CalendarEvent = {
-      id: `schedule-${Date.now()}`,
-      title: `${formState.time} ${formState.title}`,
-      name: formState.title,
-      start,
-      end: start,
-      allDay: true,
-      category: formState.category,
-      description: formState.description || undefined,
-      timeLabel: formState.time,
-    };
+    const name = categoryCreateState.name.trim();
+    const color = categoryCreateState.color.toUpperCase();
 
-    setEvents((prev) => [...prev, newEvent]);
-    setCurrentDate(start);
-    setCreateOpen(false);
-    setFormState({
-      title: "",
-      date: format(new Date(), "yyyy-MM-dd"),
-      time: "",
-      category: "exam",
-      description: "",
+    if (!name) {
+      setCategoryCreateError("카테고리 이름을 입력해 주세요.");
+      return;
+    }
+
+    if (!HEX_COLOR_REGEX.test(color)) {
+      setCategoryCreateError("색상은 #RRGGBB 형식으로 입력해 주세요.");
+      return;
+    }
+
+    setCategoryCreateError(null);
+    setIsCategoryCreating(true);
+
+    try {
+      const created = await createScheduleCategoryAPI({ name, color });
+
+      setCategories((prev) => {
+        const exists = prev.some((category) => category.id === created.id);
+        if (exists) {
+          return prev;
+        }
+
+        const withoutOther = prev.filter(
+          (category) => category.id !== OTHER_CATEGORY_KEY
+        );
+        const merged = [
+          ...withoutOther,
+          {
+            id: created.id,
+            name: created.name,
+            color: created.color.toUpperCase(),
+          },
+        ].sort((a, b) => a.name.localeCompare(b.name, "ko"));
+
+        return normalizeScheduleCategories(merged);
+      });
+
+      setFilters((prev) => ({
+        ...prev,
+        [created.id]: true,
+      }));
+      setFormState((prev) => ({
+        ...prev,
+        categoryId: created.id,
+      }));
+      setCategoryCreateState((prev) => ({
+        ...prev,
+        name: "",
+      }));
+      setCategoryCreateError(null);
+      setCategoryUpdateError(null);
+    } catch (error) {
+      setCategoryCreateError(getCategoryCreateErrorMessage(error));
+    } finally {
+      setIsCategoryCreating(false);
+    }
+  }, [
+    categoryCreateState.color,
+    categoryCreateState.name,
+    isCategoryCreating,
+    isCategoryDeleting,
+    isCategoryUpdating,
+    isScheduleCreating,
+    isScheduleDeleting,
+    isScheduleUpdating,
+    setFormState,
+  ]);
+
+  const handleStartCategoryEdit = useCallback(
+    (category: ScheduleCategoryOption) => {
+      if (category.id === OTHER_CATEGORY_KEY) {
+        return;
+      }
+
+      setEditingCategoryId(category.id);
+      setCategoryEditState({
+        name: category.name,
+        color: category.color,
+      });
+      setCategoryUpdateError(null);
+    },
+    []
+  );
+
+  const handleCancelCategoryEdit = useCallback(() => {
+    setEditingCategoryId(null);
+    setCategoryUpdateError(null);
+    setCategoryEditState({
+      name: "",
+      color: DEFAULT_CATEGORY_COLOR,
     });
-    setFormError(null);
-  };
+  }, []);
+
+  const handleUpdateCategory = useCallback(async () => {
+    if (
+      !editingCategoryId ||
+      isCategoryUpdating ||
+      isCategoryCreating ||
+      isCategoryDeleting
+    ) {
+      return;
+    }
+
+    const name = categoryEditState.name.trim();
+    const color = categoryEditState.color.toUpperCase();
+
+    if (!name) {
+      setCategoryUpdateError("카테고리 이름을 입력해 주세요.");
+      return;
+    }
+
+    if (!HEX_COLOR_REGEX.test(color)) {
+      setCategoryUpdateError("색상은 #RRGGBB 형식으로 입력해 주세요.");
+      return;
+    }
+
+    setCategoryUpdateError(null);
+    setIsCategoryUpdating(true);
+
+    try {
+      const updated = await updateScheduleCategoryAPI(editingCategoryId, {
+        name,
+        color,
+      });
+
+      setCategories((prev) => {
+        const updatedList = prev.map((category) =>
+          category.id === updated.id
+            ? {
+                ...category,
+                name: updated.name,
+                color: updated.color.toUpperCase(),
+              }
+            : category
+        );
+
+        const withoutOther = updatedList.filter(
+          (category) => category.id !== OTHER_CATEGORY_KEY
+        );
+        const merged = [...withoutOther].sort((a, b) =>
+          a.name.localeCompare(b.name, "ko")
+        );
+
+        return normalizeScheduleCategories(merged);
+      });
+
+      handleCancelCategoryEdit();
+      setCategoryCreateError(null);
+      await loadSchedules();
+    } catch (error) {
+      setCategoryUpdateError(getCategoryActionErrorMessage(error));
+    } finally {
+      setIsCategoryUpdating(false);
+    }
+  }, [
+    categoryEditState.color,
+    categoryEditState.name,
+    editingCategoryId,
+    handleCancelCategoryEdit,
+    isCategoryCreating,
+    isCategoryDeleting,
+    isCategoryUpdating,
+    loadSchedules,
+  ]);
+
+  const handleDeleteCategory = useCallback(
+    async (categoryId: string) => {
+      if (
+        categoryId === OTHER_CATEGORY_KEY ||
+        isCategoryCreating ||
+        isCategoryUpdating ||
+        isCategoryDeleting
+      ) {
+        return;
+      }
+
+      if (
+        !confirm(
+          "이 분류를 삭제하면 연결된 일정은 기타로 이동합니다. 계속할까요?"
+        )
+      ) {
+        return;
+      }
+
+      setDeletingCategoryId(categoryId);
+      setCategoryUpdateError(null);
+      setIsCategoryDeleting(true);
+
+      try {
+        const schedulesToMigrate = await fetchSchedulesAPI({
+          ...CATEGORY_MIGRATION_RANGE,
+          category: categoryId,
+        });
+
+        if (schedulesToMigrate.length > 0) {
+          const failedScheduleIds =
+            await migrateSchedulesToOtherCategory(schedulesToMigrate);
+
+          if (failedScheduleIds.length > 0) {
+            throw new Error(
+              `일정 ${failedScheduleIds.length}건을 기타로 이동하지 못해 분류 삭제를 중단했습니다. 잠시 후 다시 시도해 주세요.`
+            );
+          }
+        }
+
+        await deleteScheduleCategoryAPI(categoryId);
+
+        const withoutTarget = categories.filter(
+          (category) =>
+            category.id !== OTHER_CATEGORY_KEY && category.id !== categoryId
+        );
+        const nextCategories = normalizeScheduleCategories(withoutTarget);
+
+        setCategories(nextCategories);
+
+        setFilters((prev) => {
+          const synced = syncFiltersWithCategories(prev, nextCategories);
+          delete synced[categoryId];
+          return synced;
+        });
+
+        const nextDefaultCategoryId =
+          nextCategories[0]?.id ?? OTHER_CATEGORY_KEY;
+
+        setFormState((prev) => ({
+          ...prev,
+          categoryId:
+            prev.categoryId === categoryId
+              ? nextDefaultCategoryId
+              : prev.categoryId,
+        }));
+
+        if (editingCategoryId === categoryId) {
+          handleCancelCategoryEdit();
+        }
+
+        await loadSchedules();
+      } catch (error) {
+        setCategoryUpdateError(getCategoryActionErrorMessage(error));
+      } finally {
+        setDeletingCategoryId(null);
+        setIsCategoryDeleting(false);
+      }
+    },
+    [
+      categories,
+      editingCategoryId,
+      handleCancelCategoryEdit,
+      isCategoryCreating,
+      isCategoryDeleting,
+      isCategoryUpdating,
+      loadSchedules,
+      setFormState,
+    ]
+  );
+
+  const openCreateCategoryModal = useCallback(() => {
+    setEditingCategoryId(null);
+    setDeletingCategoryId(null);
+    setCategoryCreateState({
+      name: "",
+      color: DEFAULT_CATEGORY_COLOR,
+    });
+    setCategoryCreateError(null);
+    setCategoryUpdateError(null);
+    setIsCategoryModalOpen(true);
+  }, []);
+
+  const closeCategoryModal = useCallback(() => {
+    setIsCategoryModalOpen(false);
+    setDeletingCategoryId(null);
+    setCategoryCreateError(null);
+    setCategoryUpdateError(null);
+    setCategoryCreateState((prev) => ({
+      ...prev,
+      name: "",
+    }));
+    handleCancelCategoryEdit();
+  }, [handleCancelCategoryEdit]);
 
   return {
     view,
@@ -132,19 +595,55 @@ export function useScheduleEvents() {
     events,
     filteredEvents,
     todayEvents,
+    categories,
     categoryLabelMap,
     filters,
+    isSchedulesLoading,
+    isScheduleCreating,
+    isScheduleUpdating,
+    isScheduleDeleting,
+    isCategoryCreating,
+    isCategoryUpdating,
+    isCategoryDeleting,
+    isCategoryModalOpen,
+    loadError,
     setView,
     setCurrentDate,
     setFilters,
     createOpen,
-    setCreateOpen,
+    editingScheduleId,
+    scheduleModalMode,
     timetableOpen,
     setTimetableOpen,
+    timetableEntries,
+    timetableMeta,
+    isTimetableLoading,
+    timetableError,
     formState,
+    categoryCreateState,
+    deletingCategoryId,
+    editingCategoryId,
+    categoryEditState,
     setFormState,
+    setCategoryCreateState,
+    setCategoryEditState,
     formError,
+    categoryCreateError,
+    categoryUpdateError,
     setFormError,
+    setCategoryCreateError,
+    openCreateScheduleModal,
+    closeCreateScheduleModal,
+    enableScheduleEdit,
+    handleStartScheduleEdit,
     handleCreateSubmit,
+    handleDeleteSchedule,
+    handleCreateCategory,
+    handleStartCategoryEdit,
+    handleCancelCategoryEdit,
+    handleUpdateCategory,
+    handleDeleteCategory,
+    openCreateCategoryModal,
+    closeCategoryModal,
   };
 }

--- a/src/app/(dashboard)/educators/schedules/_hooks/useScheduleTimetable.ts
+++ b/src/app/(dashboard)/educators/schedules/_hooks/useScheduleTimetable.ts
@@ -1,0 +1,261 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { fetchLecturesAPI } from "@/services/lectures/lectures.service";
+import type {
+  ScheduleTimetableDay,
+  ScheduleTimetableEntry,
+  ScheduleTimetableMeta,
+} from "@/types/schedules";
+
+const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
+
+const TIMETABLE_COLOR_MIN_SATURATION = 64;
+const TIMETABLE_COLOR_SATURATION_RANGE = 12;
+const TIMETABLE_COLOR_MIN_LIGHTNESS = 82;
+const TIMETABLE_COLOR_LIGHTNESS_RANGE = 8;
+
+const TIMETABLE_DAY_ORDER: Record<ScheduleTimetableDay, number> = {
+  월: 0,
+  화: 1,
+  수: 2,
+  목: 3,
+  금: 4,
+  토: 5,
+  일: 6,
+};
+
+const DAY_ALIAS_MAP: Record<string, ScheduleTimetableDay> = {
+  월: "월",
+  화: "화",
+  수: "수",
+  목: "목",
+  금: "금",
+  토: "토",
+  일: "일",
+  MON: "월",
+  MONDAY: "월",
+  TUE: "화",
+  TUESDAY: "화",
+  WED: "수",
+  WEDNESDAY: "수",
+  THU: "목",
+  THURSDAY: "목",
+  FRI: "금",
+  FRIDAY: "금",
+  SAT: "토",
+  SATURDAY: "토",
+  SUN: "일",
+  SUNDAY: "일",
+};
+
+const getTimetableErrorMessage = (error: unknown) => {
+  const normalizedError = error as {
+    response?: { data?: { message?: string } };
+    message?: string;
+  };
+
+  if (typeof normalizedError.response?.data?.message === "string") {
+    return normalizedError.response.data.message;
+  }
+
+  if (typeof normalizedError.message === "string" && normalizedError.message) {
+    return normalizedError.message;
+  }
+
+  return "시간표를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.";
+};
+
+const normalizeLectureDay = (
+  day?: string | null
+): ScheduleTimetableDay | null => {
+  const normalizedDay = day?.trim();
+  if (!normalizedDay) {
+    return null;
+  }
+
+  return (
+    DAY_ALIAS_MAP[normalizedDay] ??
+    DAY_ALIAS_MAP[normalizedDay.toUpperCase()] ??
+    null
+  );
+};
+
+const normalizeLectureTime = (time?: string | null) => {
+  const normalizedTime = time?.trim();
+  if (!normalizedTime) {
+    return null;
+  }
+
+  const [hourRaw, minuteRaw] = normalizedTime.split(":");
+
+  if (hourRaw === undefined || minuteRaw === undefined) {
+    return null;
+  }
+
+  const hour = Number(hourRaw);
+  const minute = Number(minuteRaw);
+
+  if (
+    Number.isNaN(hour) ||
+    Number.isNaN(minute) ||
+    hour < 0 ||
+    hour > 23 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return null;
+  }
+
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+};
+
+const getHashBySeed = (seed: string) => {
+  let hash = 0;
+
+  for (let index = 0; index < seed.length; index += 1) {
+    hash = (hash << 5) - hash + seed.charCodeAt(index);
+    hash |= 0;
+  }
+
+  return Math.abs(hash);
+};
+
+const getTimetableColorBySeed = (seed: string) => {
+  const hash = getHashBySeed(seed);
+  const hue = hash % 360;
+  const saturation =
+    TIMETABLE_COLOR_MIN_SATURATION + (hash % TIMETABLE_COLOR_SATURATION_RANGE);
+  const lightness =
+    TIMETABLE_COLOR_MIN_LIGHTNESS +
+    (Math.floor(hash / 360) % TIMETABLE_COLOR_LIGHTNESS_RANGE);
+
+  return `hsl(${hue} ${saturation}% ${lightness}%)`;
+};
+
+const isServerColorHex = (value: string) => HEX_COLOR_REGEX.test(value);
+
+const isServerColorValid = (value: string) => {
+  if (isServerColorHex(value)) {
+    return true;
+  }
+
+  if (
+    typeof window !== "undefined" &&
+    typeof window.CSS !== "undefined" &&
+    typeof window.CSS.supports === "function"
+  ) {
+    return window.CSS.supports("color", value);
+  }
+
+  return false;
+};
+
+const getTimetableColor = (lectureId: string, serverColor?: string | null) => {
+  const normalizedServerColor = serverColor?.trim();
+
+  if (normalizedServerColor && isServerColorValid(normalizedServerColor)) {
+    return isServerColorHex(normalizedServerColor)
+      ? normalizedServerColor.toUpperCase()
+      : normalizedServerColor;
+  }
+
+  return getTimetableColorBySeed(lectureId);
+};
+
+export function useScheduleTimetable() {
+  const [timetableOpen, setTimetableOpen] = useState(false);
+  const [timetableEntries, setTimetableEntries] = useState<
+    ScheduleTimetableEntry[]
+  >([]);
+  const [timetableMeta, setTimetableMeta] = useState<ScheduleTimetableMeta>({
+    academy: "개설 강의 시간표",
+    term: `${new Date().getFullYear()} 주간 시간표`,
+  });
+  const [isTimetableLoading, setIsTimetableLoading] = useState(false);
+  const [timetableError, setTimetableError] = useState<string | null>(null);
+
+  const loadTimetable = useCallback(async () => {
+    setIsTimetableLoading(true);
+
+    try {
+      const response = await fetchLecturesAPI({
+        page: 1,
+        limit: 100,
+      });
+
+      const nextEntries = response.lectures
+        .flatMap((lecture, lectureIndex) => {
+          return (lecture.lectureTimes ?? []).flatMap(
+            (lectureTime, timeIndex) => {
+              const day = normalizeLectureDay(lectureTime.day);
+              const startTime = normalizeLectureTime(lectureTime.startTime);
+              const endTime = normalizeLectureTime(lectureTime.endTime);
+
+              if (!day || !startTime || !endTime) {
+                return [];
+              }
+
+              return {
+                id: `${lecture.id}-${lectureIndex}-${timeIndex}`,
+                title: lecture.title,
+                day,
+                startTime,
+                endTime,
+                color: getTimetableColor(lecture.id, lecture.color),
+              };
+            }
+          );
+        })
+        .sort((a, b) => {
+          const dayOrderDiff =
+            TIMETABLE_DAY_ORDER[a.day] - TIMETABLE_DAY_ORDER[b.day];
+          if (dayOrderDiff !== 0) {
+            return dayOrderDiff;
+          }
+
+          return a.startTime.localeCompare(b.startTime);
+        });
+
+      const firstInstructorName = response.lectures.find((lecture) => {
+        return (
+          typeof lecture.instructorName === "string" &&
+          lecture.instructorName.trim().length > 0
+        );
+      })?.instructorName;
+
+      setTimetableEntries(nextEntries);
+      setTimetableMeta({
+        academy: firstInstructorName
+          ? `${firstInstructorName} 강사 개설 시간표`
+          : "개설 강의 시간표",
+        term: `${new Date().getFullYear()} 주간 시간표`,
+      });
+      setTimetableError(null);
+    } catch (error) {
+      setTimetableEntries([]);
+      setTimetableError(getTimetableErrorMessage(error));
+    } finally {
+      setIsTimetableLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!timetableOpen) {
+      return;
+    }
+
+    void loadTimetable();
+  }, [loadTimetable, timetableOpen]);
+
+  return {
+    timetableOpen,
+    setTimetableOpen,
+    timetableEntries,
+    timetableMeta,
+    isTimetableLoading,
+    timetableError,
+    reloadTimetable: loadTimetable,
+  };
+}

--- a/src/app/(dashboard)/educators/schedules/_modals/ScheduleCategoryManageModal.tsx
+++ b/src/app/(dashboard)/educators/schedules/_modals/ScheduleCategoryManageModal.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { memo } from "react";
+import { Check, Pencil, Trash2, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type {
+  ScheduleCategoryCreateState,
+  ScheduleCategoryEditState,
+  ScheduleCategoryOption,
+} from "@/types/schedules";
+
+type ScheduleCategoryManageModalProps = {
+  open: boolean;
+  categories: ScheduleCategoryOption[];
+  isCategoryCreating: boolean;
+  isCategoryUpdating: boolean;
+  categoryCreateState: ScheduleCategoryCreateState;
+  onCategoryCreateStateChange: (
+    updater:
+      | ScheduleCategoryCreateState
+      | ((prev: ScheduleCategoryCreateState) => ScheduleCategoryCreateState)
+  ) => void;
+  categoryCreateError: string | null;
+  onCreateCategory: () => void;
+  deletingCategoryId: string | null;
+  editingCategoryId: string | null;
+  categoryEditState: ScheduleCategoryEditState;
+  onCategoryEditStateChange: (
+    updater:
+      | ScheduleCategoryEditState
+      | ((prev: ScheduleCategoryEditState) => ScheduleCategoryEditState)
+  ) => void;
+  categoryUpdateError: string | null;
+  onStartCategoryEdit: (category: ScheduleCategoryOption) => void;
+  onCancelCategoryEdit: () => void;
+  onUpdateCategory: () => void;
+  onDeleteCategory: (categoryId: string) => void;
+  onOpenChange: (open: boolean) => void;
+};
+
+function ScheduleCategoryManageModalComponent({
+  open,
+  categories,
+  isCategoryCreating,
+  isCategoryUpdating,
+  categoryCreateState,
+  onCategoryCreateStateChange,
+  categoryCreateError,
+  onCreateCategory,
+  deletingCategoryId,
+  editingCategoryId,
+  categoryEditState,
+  onCategoryEditStateChange,
+  categoryUpdateError,
+  onStartCategoryEdit,
+  onCancelCategoryEdit,
+  onUpdateCategory,
+  onDeleteCategory,
+  onOpenChange,
+}: ScheduleCategoryManageModalProps) {
+  const isCategoryActionLocked =
+    isCategoryCreating || isCategoryUpdating || deletingCategoryId !== null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>분류 관리</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          <div className="space-y-3 rounded-lg border border-dashed border-neutral-300 p-4">
+            <div>
+              <p className="text-sm font-semibold text-foreground">
+                새 분류 추가
+              </p>
+              <p className="text-xs text-muted-foreground">
+                이름과 색상을 입력해 바로 등록할 수 있습니다.
+              </p>
+            </div>
+            <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+              <Input
+                value={categoryCreateState.name}
+                onChange={(event) =>
+                  onCategoryCreateStateChange((prev) => ({
+                    ...prev,
+                    name: event.target.value,
+                  }))
+                }
+                placeholder="예: 과제 제출"
+                disabled={isCategoryActionLocked}
+                className="h-10"
+              />
+              <div className="flex items-center gap-2">
+                <Input
+                  type="color"
+                  value={categoryCreateState.color}
+                  onChange={(event) =>
+                    onCategoryCreateStateChange((prev) => ({
+                      ...prev,
+                      color: event.target.value,
+                    }))
+                  }
+                  disabled={isCategoryActionLocked}
+                  className="h-9 w-9 cursor-pointer overflow-hidden rounded-full border p-0 [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded-full [&::-webkit-color-swatch]:border-0 [&::-moz-color-swatch]:border-0"
+                />
+                <Button
+                  type="button"
+                  className="h-9 px-3 text-xs"
+                  onClick={onCreateCategory}
+                  disabled={isCategoryActionLocked}
+                >
+                  {isCategoryCreating ? "추가 중..." : "분류 추가"}
+                </Button>
+              </div>
+            </div>
+            {categoryCreateError ? (
+              <p className="text-xs text-destructive">{categoryCreateError}</p>
+            ) : null}
+          </div>
+
+          <div className="space-y-3">
+            <div>
+              <p className="text-sm font-semibold text-foreground">
+                기존 분류 수정
+              </p>
+              <p className="text-xs text-muted-foreground">
+                분류 이름/색상을 수정할 수 있습니다. (기타 분류 제외)
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              {categories.map((category) => {
+                const isEditing = editingCategoryId === category.id;
+                const isReadonlyCategory = category.id === "other";
+                const isDeleting = deletingCategoryId === category.id;
+
+                return (
+                  <div
+                    key={category.id}
+                    className="space-y-2 rounded-md border border-neutral-200 p-3"
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="flex items-center gap-2 text-sm font-medium text-foreground">
+                        <span
+                          className="h-2 w-2 rounded-full"
+                          style={{ backgroundColor: category.color }}
+                        />
+                        {category.name}
+                      </span>
+
+                      {isReadonlyCategory ? (
+                        <span className="text-xs text-muted-foreground">
+                          고정 분류
+                        </span>
+                      ) : isEditing ? (
+                        <div className="flex items-center gap-1">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="default"
+                            className="h-7 w-7 p-0"
+                            onClick={onCancelCategoryEdit}
+                            disabled={isCategoryActionLocked}
+                            aria-label="분류 수정 취소"
+                          >
+                            <X className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="default"
+                            className="h-7 w-7 p-0"
+                            onClick={onUpdateCategory}
+                            disabled={isCategoryActionLocked}
+                            aria-label="분류 수정 저장"
+                          >
+                            <Check className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      ) : (
+                        <div className="flex items-center gap-1">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="default"
+                            className="h-7 w-7 p-0"
+                            onClick={() => onStartCategoryEdit(category)}
+                            disabled={isCategoryActionLocked}
+                            aria-label={`${category.name} 분류 수정`}
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="default"
+                            className="h-7 w-7 p-0 text-destructive"
+                            onClick={() => onDeleteCategory(category.id)}
+                            disabled={isCategoryActionLocked}
+                            aria-label={`${category.name} 분류 삭제`}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+
+                    {isDeleting ? (
+                      <p className="text-xs text-muted-foreground">
+                        삭제 중...
+                      </p>
+                    ) : null}
+
+                    {isEditing ? (
+                      <div className="space-y-2">
+                        <Label
+                          htmlFor={`category-name-${category.id}`}
+                          className="sr-only"
+                        >
+                          분류 이름
+                        </Label>
+                        <Input
+                          id={`category-name-${category.id}`}
+                          value={categoryEditState.name}
+                          onChange={(event) =>
+                            onCategoryEditStateChange((prev) => ({
+                              ...prev,
+                              name: event.target.value,
+                            }))
+                          }
+                          disabled={isCategoryActionLocked}
+                          className="h-9"
+                        />
+                        <div className="flex items-center gap-2">
+                          <Input
+                            type="color"
+                            value={categoryEditState.color}
+                            onChange={(event) =>
+                              onCategoryEditStateChange((prev) => ({
+                                ...prev,
+                                color: event.target.value,
+                              }))
+                            }
+                            disabled={isCategoryActionLocked}
+                            className="h-8 w-8 cursor-pointer overflow-hidden rounded-full border p-0 [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded-full [&::-webkit-color-swatch]:border-0 [&::-moz-color-swatch]:border-0"
+                          />
+                        </div>
+                        {categoryUpdateError ? (
+                          <p className="text-xs text-destructive">
+                            {categoryUpdateError}
+                          </p>
+                        ) : null}
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isCategoryActionLocked}
+          >
+            닫기
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export const ScheduleCategoryManageModal = memo(
+  ScheduleCategoryManageModalComponent
+);
+ScheduleCategoryManageModal.displayName = "ScheduleCategoryManageModal";

--- a/src/app/(dashboard)/educators/schedules/_modals/ScheduleCreateModal.tsx
+++ b/src/app/(dashboard)/educators/schedules/_modals/ScheduleCreateModal.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { memo } from "react";
+
 import SelectBtn from "@/components/common/button/SelectBtn";
+import { DatePickerInput } from "@/components/common/input/DatePickerField";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -12,15 +15,20 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  scheduleCategoryOptions,
-  type ScheduleCategory,
-} from "@/data/schedules.mock";
-import type { ScheduleFormState } from "@/app/(dashboard)/educators/schedules/_hooks/useScheduleEvents";
+import { Checkbox } from "@/components/ui/checkbox";
+import type {
+  ScheduleCategoryOption,
+  ScheduleFormState,
+  ScheduleModalMode,
+} from "@/types/schedules";
 
 type ScheduleCreateModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  categoryOptions: ScheduleCategoryOption[];
+  isSubmitting: boolean;
+  mode: ScheduleModalMode;
+  isDeleting: boolean;
   formState: ScheduleFormState;
   onFormChange: (
     updater:
@@ -28,24 +36,74 @@ type ScheduleCreateModalProps = {
       | ((prev: ScheduleFormState) => ScheduleFormState)
   ) => void;
   formError: string | null;
-  onClose: () => void;
+  onEnableEdit: () => void;
   onSubmit: () => void;
+  onDelete: () => void;
 };
 
-export function ScheduleCreateModal({
+const normalizeTimeInput = (value: string) => {
+  const digits = value.replace(/\D/g, "").slice(0, 4);
+
+  if (digits.length <= 2) {
+    return digits;
+  }
+
+  if (digits.length === 3) {
+    const firstTwo = Number(digits.slice(0, 2));
+    if (Number.isNaN(firstTwo) || firstTwo > 23) {
+      return `0${digits[0]}:${digits.slice(1)}`;
+    }
+    return `${digits.slice(0, 2)}:${digits.slice(2)}`;
+  }
+
+  return `${digits.slice(0, 2)}:${digits.slice(2, 4)}`;
+};
+
+const getMeridiemLabel = (time: string) => {
+  const matched = time.match(/^([01]\d|2[0-3]):([0-5]\d)$/);
+  if (!matched) {
+    return null;
+  }
+
+  const hour = Number(matched[1]);
+  return hour < 12
+    ? { label: "AM 오전", className: "bg-sky-100 text-sky-700" }
+    : { label: "PM 오후", className: "bg-amber-100 text-amber-700" };
+};
+
+function ScheduleCreateModalComponent({
   open,
   onOpenChange,
+  categoryOptions,
+  isSubmitting,
+  mode,
+  isDeleting,
   formState,
   onFormChange,
   formError,
-  onClose,
+  onEnableEdit,
   onSubmit,
+  onDelete,
 }: ScheduleCreateModalProps) {
+  const isEditMode = mode === "view" || mode === "edit";
+  const isEditableMode = mode === "edit";
+  const isReadonlyView = mode === "view";
+  const isActionLocked = isSubmitting || isDeleting;
+  const isFormDisabled = isActionLocked || isReadonlyView;
+  const startMeridiem = getMeridiemLabel(formState.startTime);
+  const endMeridiem = getMeridiemLabel(formState.endTime);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>일정 생성</DialogTitle>
+          <DialogTitle>
+            {isEditMode
+              ? isReadonlyView
+                ? "일정 확인"
+                : "일정 수정"
+              : "일정 생성"}
+          </DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
           <div className="space-y-2">
@@ -58,60 +116,126 @@ export function ScheduleCreateModal({
               }
               placeholder="예: 수학 모의고사"
               className="h-11"
+              disabled={isFormDisabled}
             />
           </div>
-          <div className="grid gap-3 md:grid-cols-2">
+          <div className="space-y-3 rounded-lg border border-neutral-200 p-3">
             <div className="space-y-2">
-              <Label htmlFor="schedule-date">일정 날짜</Label>
-              <Input
+              <div className="flex items-center justify-between gap-2">
+                <Label htmlFor="schedule-date">일정 날짜</Label>
+                <label className="inline-flex items-center gap-1.5 px-1 py-0.5 text-xs font-medium text-neutral-700">
+                  <Checkbox
+                    checked={formState.isAllDay}
+                    disabled={isFormDisabled}
+                    onCheckedChange={(checked) =>
+                      onFormChange((prev) => ({
+                        ...prev,
+                        isAllDay: Boolean(checked),
+                        startTime: Boolean(checked) ? "" : prev.startTime,
+                        endTime: Boolean(checked) ? "" : prev.endTime,
+                      }))
+                    }
+                  />
+                  종일 일정
+                </label>
+              </div>
+              <DatePickerInput
                 id="schedule-date"
-                type="date"
                 value={formState.date}
-                onChange={(event) =>
+                onChangeAction={(value) =>
                   onFormChange((prev) => ({
                     ...prev,
-                    date: event.target.value,
+                    date: value,
                   }))
                 }
-                className="h-11"
+                className="h-11 rounded-md border-input text-sm"
+                disabled={isFormDisabled}
               />
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="schedule-time">시간</Label>
-              <Input
-                id="schedule-time"
-                type="time"
-                value={formState.time}
-                onChange={(event) =>
-                  onFormChange((prev) => ({
-                    ...prev,
-                    time: event.target.value,
-                  }))
-                }
-                className="h-11"
-              />
+
+            <div className="grid gap-3">
+              <div className="space-y-2">
+                <Label htmlFor="schedule-start-time">시작 시간</Label>
+                <div className="flex items-center gap-2">
+                  <Input
+                    id="schedule-start-time"
+                    type="text"
+                    value={formState.startTime}
+                    onChange={(event) =>
+                      onFormChange((prev) => ({
+                        ...prev,
+                        startTime: normalizeTimeInput(event.target.value),
+                      }))
+                    }
+                    disabled={isFormDisabled || formState.isAllDay}
+                    placeholder="시작 시간"
+                    inputMode="numeric"
+                    maxLength={5}
+                    className="h-11"
+                  />
+                  <span
+                    className={`inline-flex h-9 min-w-[76px] items-center justify-center rounded-full px-3 text-xs font-semibold ${
+                      startMeridiem?.className ??
+                      "bg-muted text-muted-foreground"
+                    }`}
+                  >
+                    {startMeridiem?.label ?? "시간 입력"}
+                  </span>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="schedule-end-time">종료 시간</Label>
+                <div className="flex items-center gap-2">
+                  <Input
+                    id="schedule-end-time"
+                    type="text"
+                    value={formState.endTime}
+                    onChange={(event) =>
+                      onFormChange((prev) => ({
+                        ...prev,
+                        endTime: normalizeTimeInput(event.target.value),
+                      }))
+                    }
+                    disabled={isFormDisabled || formState.isAllDay}
+                    placeholder="종료 시간"
+                    inputMode="numeric"
+                    maxLength={5}
+                    className="h-11"
+                  />
+                  <span
+                    className={`inline-flex h-9 min-w-[76px] items-center justify-center rounded-full px-3 text-xs font-semibold ${
+                      endMeridiem?.className ?? "bg-muted text-muted-foreground"
+                    }`}
+                  >
+                    {endMeridiem?.label ?? "시간 입력"}
+                  </span>
+                </div>
+              </div>
             </div>
           </div>
           <div className="space-y-2">
             <Label>일정 분류</Label>
             <SelectBtn
-              value={formState.category}
+              value={formState.categoryId}
               onChange={(value) =>
                 onFormChange((prev) => ({
                   ...prev,
-                  category: value as ScheduleCategory,
+                  categoryId: value,
                 }))
               }
               placeholder="분류 선택"
-              options={scheduleCategoryOptions.map((option) => ({
-                label: option.label,
-                value: option.value,
+              options={categoryOptions.map((option) => ({
+                label: option.name,
+                value: option.id,
               }))}
+              disabled={isFormDisabled}
               variant="figma"
               optionSize="sm"
               className="h-11"
             />
           </div>
+
           <div className="space-y-2">
             <Label htmlFor="schedule-desc">일정 내용</Label>
             <Textarea
@@ -125,6 +249,7 @@ export function ScheduleCreateModal({
               }
               placeholder="예: 모의고사 대비 특강 진행"
               className="min-h-[96px]"
+              disabled={isFormDisabled}
             />
           </div>
           {formError ? (
@@ -132,14 +257,45 @@ export function ScheduleCreateModal({
           ) : null}
         </div>
         <DialogFooter className="mt-4">
-          <Button type="button" variant="outline" onClick={onClose}>
-            취소
-          </Button>
-          <Button type="button" className="gap-2" onClick={onSubmit}>
-            등록
+          {isEditableMode ? (
+            <Button
+              type="button"
+              variant="outline"
+              className="text-destructive"
+              onClick={onDelete}
+              disabled={isActionLocked}
+            >
+              {isDeleting ? "삭제 중..." : "삭제"}
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            className="gap-2"
+            onClick={() => {
+              if (isReadonlyView) {
+                onEnableEdit();
+                return;
+              }
+
+              onSubmit();
+            }}
+            disabled={isActionLocked}
+          >
+            {isReadonlyView
+              ? "수정"
+              : isSubmitting
+                ? isEditMode
+                  ? "저장 중..."
+                  : "등록 중..."
+                : isEditMode
+                  ? "저장"
+                  : "등록"}
           </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
   );
 }
+
+export const ScheduleCreateModal = memo(ScheduleCreateModalComponent);
+ScheduleCreateModal.displayName = "ScheduleCreateModal";

--- a/src/app/(dashboard)/educators/schedules/_modals/ScheduleTimetableModal.tsx
+++ b/src/app/(dashboard)/educators/schedules/_modals/ScheduleTimetableModal.tsx
@@ -1,33 +1,165 @@
 "use client";
 
-import {
-  timetableEntries,
-  timetableMeta,
-  type TimetableDay,
-} from "@/data/schedules.mock";
+import { memo, useMemo } from "react";
+
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import type {
+  ScheduleTimetableDay,
+  ScheduleTimetableEntry,
+  ScheduleTimetableMeta,
+} from "@/types/schedules";
 
-const timetableDays: TimetableDay[] = ["월", "화", "수", "목", "금", "토"];
-const timetableStartHour = 11;
-const timetableEndHour = 23;
+const timetableDays: ScheduleTimetableDay[] = [
+  "월",
+  "화",
+  "수",
+  "목",
+  "금",
+  "토",
+  "일",
+];
+const DEFAULT_TIMETABLE_START_HOUR = 8;
+const DEFAULT_TIMETABLE_END_HOUR = 24;
+const MIN_TIMETABLE_START_HOUR = 6;
+const MAX_TIMETABLE_END_HOUR = 24;
+const TIMETABLE_AXIS_PADDING_MINUTES = 60;
 const timetableRowHeight = 48;
-const timetableRowCount = timetableEndHour - timetableStartHour;
+
+type TimetableAxis = {
+  startHour: number;
+  endHour: number;
+  rowCount: number;
+  gridHeight: number;
+  minMinutes: number;
+  maxMinutes: number;
+};
+
+const clampNumber = (value: number, min: number, max: number) => {
+  return Math.min(Math.max(value, min), max);
+};
 
 const toMinutes = (time: string) => {
   const [hours, minutes] = time.split(":").map(Number);
   return hours * 60 + minutes;
 };
 
-const getTimetableBlockStyle = (startTime: string, endTime: string) => {
+const getDefaultTimetableAxis = (): TimetableAxis => {
+  const rowCount = DEFAULT_TIMETABLE_END_HOUR - DEFAULT_TIMETABLE_START_HOUR;
+
+  return {
+    startHour: DEFAULT_TIMETABLE_START_HOUR,
+    endHour: DEFAULT_TIMETABLE_END_HOUR,
+    rowCount,
+    gridHeight: rowCount * timetableRowHeight,
+    minMinutes: DEFAULT_TIMETABLE_START_HOUR * 60,
+    maxMinutes: DEFAULT_TIMETABLE_END_HOUR * 60,
+  };
+};
+
+const buildTimetableAxis = (
+  entries: ScheduleTimetableEntry[]
+): TimetableAxis => {
+  const validRanges = entries
+    .map((entry) => {
+      const startMinutes = toMinutes(entry.startTime);
+      const endMinutes = toMinutes(entry.endTime);
+
+      if (
+        Number.isNaN(startMinutes) ||
+        Number.isNaN(endMinutes) ||
+        endMinutes <= startMinutes
+      ) {
+        return null;
+      }
+
+      return {
+        startMinutes,
+        endMinutes,
+      };
+    })
+    .filter((range): range is { startMinutes: number; endMinutes: number } => {
+      return range !== null;
+    });
+
+  if (validRanges.length === 0) {
+    return getDefaultTimetableAxis();
+  }
+
+  const minStartMinutes = Math.min(
+    ...validRanges.map((range) => range.startMinutes)
+  );
+  const maxEndMinutes = Math.max(
+    ...validRanges.map((range) => range.endMinutes)
+  );
+
+  const paddedStartMinutes = clampNumber(
+    minStartMinutes - TIMETABLE_AXIS_PADDING_MINUTES,
+    MIN_TIMETABLE_START_HOUR * 60,
+    MAX_TIMETABLE_END_HOUR * 60
+  );
+  const paddedEndMinutes = clampNumber(
+    maxEndMinutes + TIMETABLE_AXIS_PADDING_MINUTES,
+    MIN_TIMETABLE_START_HOUR * 60,
+    MAX_TIMETABLE_END_HOUR * 60
+  );
+
+  let startHour = Math.floor(paddedStartMinutes / 60);
+  startHour = clampNumber(
+    startHour,
+    MIN_TIMETABLE_START_HOUR,
+    MAX_TIMETABLE_END_HOUR - 1
+  );
+
+  let endHour = Math.ceil(paddedEndMinutes / 60);
+  endHour = clampNumber(endHour, startHour + 1, MAX_TIMETABLE_END_HOUR);
+
+  const rowCount = Math.max(endHour - startHour, 1);
+
+  return {
+    startHour,
+    endHour,
+    rowCount,
+    gridHeight: rowCount * timetableRowHeight,
+    minMinutes: startHour * 60,
+    maxMinutes: endHour * 60,
+  };
+};
+
+const getTimetableBlockStyle = (
+  startTime: string,
+  endTime: string,
+  timeAxis: TimetableAxis
+) => {
+  const { minMinutes, maxMinutes } = timeAxis;
   const startMinutes = toMinutes(startTime);
   const endMinutes = toMinutes(endTime);
-  const offsetMinutes = startMinutes - timetableStartHour * 60;
-  const durationMinutes = Math.max(endMinutes - startMinutes, 30);
+
+  if (Number.isNaN(startMinutes) || Number.isNaN(endMinutes)) {
+    return null;
+  }
+
+  const clippedStartMinutes = Math.max(startMinutes, minMinutes);
+  const clippedEndMinutes = Math.min(endMinutes, maxMinutes);
+
+  if (
+    clippedEndMinutes <= minMinutes ||
+    clippedStartMinutes >= maxMinutes ||
+    clippedEndMinutes <= clippedStartMinutes
+  ) {
+    return null;
+  }
+
+  const rawDuration = Math.max(clippedEndMinutes - clippedStartMinutes, 30);
+  const durationMinutes = Math.min(
+    rawDuration,
+    maxMinutes - clippedStartMinutes
+  );
+  const offsetMinutes = clippedStartMinutes - minMinutes;
 
   return {
     top: (offsetMinutes / 60) * timetableRowHeight,
@@ -38,12 +170,26 @@ const getTimetableBlockStyle = (startTime: string, endTime: string) => {
 type ScheduleTimetableModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  entries: ScheduleTimetableEntry[];
+  meta: ScheduleTimetableMeta;
+  isLoading: boolean;
+  errorMessage: string | null;
 };
 
-export function ScheduleTimetableModal({
+function ScheduleTimetableModalComponent({
   open,
   onOpenChange,
+  entries,
+  meta,
+  isLoading,
+  errorMessage,
 }: ScheduleTimetableModalProps) {
+  const timeAxis = useMemo(() => {
+    return buildTimetableAxis(entries);
+  }, [entries]);
+
+  const gridTemplateColumns = `80px repeat(${timetableDays.length}, minmax(0, 1fr))`;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-5xl">
@@ -53,15 +199,32 @@ export function ScheduleTimetableModal({
         <div className="space-y-4">
           <div className="rounded-xl border border-[#f2c7d4] bg-[#fbd1dd] px-4 py-3 text-center">
             <p className="text-sm font-semibold text-[#3f2b35]">
-              {timetableMeta.academy}
+              {meta.academy}
             </p>
-            <p className="text-lg font-bold text-[#2f2030]">
-              {timetableMeta.term}
-            </p>
+            <p className="text-lg font-bold text-[#2f2030]">{meta.term}</p>
           </div>
 
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground">
+              시간표를 불러오는 중입니다...
+            </p>
+          ) : null}
+
+          {errorMessage ? (
+            <p className="text-sm text-destructive">{errorMessage}</p>
+          ) : null}
+
+          {!isLoading && !errorMessage && entries.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              등록된 강의 시간표가 없습니다.
+            </p>
+          ) : null}
+
           <div className="space-y-3">
-            <div className="grid grid-cols-[80px_repeat(6,minmax(0,1fr))] gap-2 text-sm font-semibold text-muted-foreground">
+            <div
+              className="grid gap-2 text-sm font-semibold text-muted-foreground"
+              style={{ gridTemplateColumns }}
+            >
               <span />
               {timetableDays.map((day) => (
                 <div key={day} className="text-center">
@@ -70,14 +233,18 @@ export function ScheduleTimetableModal({
               ))}
             </div>
 
-            <div className="grid grid-cols-[80px_repeat(6,minmax(0,1fr))] gap-2">
+            <div className="grid gap-2" style={{ gridTemplateColumns }}>
               <div className="flex flex-col text-xs text-muted-foreground">
-                {Array.from({ length: timetableRowCount }, (_, index) => {
-                  const hour = timetableStartHour + index;
+                {Array.from({ length: timeAxis.rowCount + 1 }, (_, index) => {
+                  const hour = timeAxis.startHour + index;
+                  const isBoundaryLabel = index === timeAxis.rowCount;
+
                   return (
                     <div
                       key={`time-${hour}`}
-                      className="flex h-12 items-start justify-end pr-2"
+                      className={`flex items-start justify-end pr-2 ${
+                        isBoundaryLabel ? "h-0" : "h-12"
+                      }`}
                     >
                       {String(hour).padStart(2, "0")}:00
                     </div>
@@ -86,16 +253,15 @@ export function ScheduleTimetableModal({
               </div>
 
               {timetableDays.map((day) => {
-                const dayEntries = timetableEntries.filter(
-                  (entry) => entry.day === day
-                );
+                const dayEntries = entries.filter((entry) => entry.day === day);
                 return (
                   <div
                     key={day}
-                    className="relative h-[576px] rounded-xl border border-slate-100 bg-white"
+                    className="relative rounded-xl border border-slate-100 bg-white"
+                    style={{ height: timeAxis.gridHeight }}
                   >
                     <div className="absolute inset-0 flex flex-col">
-                      {Array.from({ length: timetableRowCount }).map(
+                      {Array.from({ length: timeAxis.rowCount }).map(
                         (_, index) => (
                           <div
                             key={`row-${day}-${index}`}
@@ -107,8 +273,14 @@ export function ScheduleTimetableModal({
                     {dayEntries.map((entry) => {
                       const style = getTimetableBlockStyle(
                         entry.startTime,
-                        entry.endTime
+                        entry.endTime,
+                        timeAxis
                       );
+
+                      if (!style) {
+                        return null;
+                      }
+
                       return (
                         <div
                           key={entry.id}
@@ -136,3 +308,6 @@ export function ScheduleTimetableModal({
     </Dialog>
   );
 }
+
+export const ScheduleTimetableModal = memo(ScheduleTimetableModalComponent);
+ScheduleTimetableModal.displayName = "ScheduleTimetableModal";

--- a/src/app/(dashboard)/educators/schedules/page.tsx
+++ b/src/app/(dashboard)/educators/schedules/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback } from "react";
 import { LayoutGrid, Calendar as CalendarIcon } from "lucide-react";
 
 import { SectionHeader } from "@/components/common/SectionHeader";
@@ -9,6 +10,7 @@ import { useSetBreadcrumb } from "@/hooks/useBreadcrumb";
 import { ScheduleCalendar } from "@/app/(dashboard)/educators/schedules/_components/ScheduleCalendar";
 import { ScheduleSidebar } from "@/app/(dashboard)/educators/schedules/_components/ScheduleSidebar";
 import { ScheduleCreateModal } from "@/app/(dashboard)/educators/schedules/_modals/ScheduleCreateModal";
+import { ScheduleCategoryManageModal } from "@/app/(dashboard)/educators/schedules/_modals/ScheduleCategoryManageModal";
 import { ScheduleTimetableModal } from "@/app/(dashboard)/educators/schedules/_modals/ScheduleTimetableModal";
 
 export default function EducatorsSchedulesPage() {
@@ -19,21 +21,72 @@ export default function EducatorsSchedulesPage() {
     currentDate,
     filteredEvents,
     todayEvents,
+    categories,
     categoryLabelMap,
     filters,
+    isSchedulesLoading,
+    isScheduleCreating,
+    isScheduleUpdating,
+    isScheduleDeleting,
+    isCategoryCreating,
+    isCategoryUpdating,
+    isCategoryDeleting,
+    isCategoryModalOpen,
+    loadError,
     setView,
     setCurrentDate,
     setFilters,
     createOpen,
-    setCreateOpen,
+    scheduleModalMode,
     timetableOpen,
     setTimetableOpen,
+    timetableEntries,
+    timetableMeta,
+    isTimetableLoading,
+    timetableError,
     formState,
+    categoryCreateState,
+    deletingCategoryId,
+    editingCategoryId,
+    categoryEditState,
     setFormState,
+    setCategoryCreateState,
+    setCategoryEditState,
     formError,
-    setFormError,
+    categoryCreateError,
+    categoryUpdateError,
+    openCreateScheduleModal,
+    closeCreateScheduleModal,
+    enableScheduleEdit,
+    handleStartScheduleEdit,
     handleCreateSubmit,
+    handleDeleteSchedule,
+    handleCreateCategory,
+    handleStartCategoryEdit,
+    handleCancelCategoryEdit,
+    handleUpdateCategory,
+    handleDeleteCategory,
+    openCreateCategoryModal,
+    closeCategoryModal,
   } = useScheduleEvents();
+
+  const handleCreateModalOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        closeCreateScheduleModal();
+      }
+    },
+    [closeCreateScheduleModal]
+  );
+
+  const handleCategoryModalOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        closeCategoryModal();
+      }
+    },
+    [closeCategoryModal]
+  );
 
   return (
     <div className="container mx-auto space-y-8 p-6">
@@ -46,7 +99,7 @@ export default function EducatorsSchedulesPage() {
               type="button"
               variant="outline"
               className="h-10 gap-2"
-              onClick={() => setCreateOpen(true)}
+              onClick={openCreateScheduleModal}
             >
               <CalendarIcon className="h-4 w-4" />
               일정 생성
@@ -71,33 +124,75 @@ export default function EducatorsSchedulesPage() {
           events={filteredEvents}
           onViewChange={setView}
           onNavigate={setCurrentDate}
+          onSelectEvent={handleStartScheduleEdit}
         />
         <ScheduleSidebar
+          categories={categories}
           filters={filters}
           onFilterChange={setFilters}
           todayEvents={todayEvents}
+          onSelectTodayEvent={handleStartScheduleEdit}
           categoryLabelMap={categoryLabelMap}
+          isCategoryActionLocked={
+            isCategoryCreating || isCategoryUpdating || isCategoryDeleting
+          }
+          onOpenCreateCategoryModal={openCreateCategoryModal}
         />
       </div>
 
+      {isSchedulesLoading ? (
+        <p className="text-sm text-muted-foreground">
+          일정을 불러오는 중입니다...
+        </p>
+      ) : null}
+
+      {loadError ? (
+        <p className="text-sm text-destructive">{loadError}</p>
+      ) : null}
+
       <ScheduleCreateModal
         open={createOpen}
-        onOpenChange={(open) => {
-          setCreateOpen(open);
-          if (!open) {
-            setFormError(null);
-          }
-        }}
+        onOpenChange={handleCreateModalOpenChange}
+        categoryOptions={categories}
+        isSubmitting={isScheduleCreating || isScheduleUpdating}
+        mode={scheduleModalMode}
+        isDeleting={isScheduleDeleting}
         formState={formState}
         onFormChange={setFormState}
         formError={formError}
-        onClose={() => setCreateOpen(false)}
+        onEnableEdit={enableScheduleEdit}
         onSubmit={handleCreateSubmit}
+        onDelete={handleDeleteSchedule}
+      />
+
+      <ScheduleCategoryManageModal
+        open={isCategoryModalOpen}
+        categories={categories}
+        isCategoryCreating={isCategoryCreating}
+        isCategoryUpdating={isCategoryUpdating}
+        deletingCategoryId={deletingCategoryId}
+        categoryCreateState={categoryCreateState}
+        onCategoryCreateStateChange={setCategoryCreateState}
+        categoryCreateError={categoryCreateError}
+        onCreateCategory={handleCreateCategory}
+        editingCategoryId={editingCategoryId}
+        categoryEditState={categoryEditState}
+        onCategoryEditStateChange={setCategoryEditState}
+        categoryUpdateError={categoryUpdateError}
+        onStartCategoryEdit={handleStartCategoryEdit}
+        onCancelCategoryEdit={handleCancelCategoryEdit}
+        onUpdateCategory={handleUpdateCategory}
+        onDeleteCategory={handleDeleteCategory}
+        onOpenChange={handleCategoryModalOpenChange}
       />
 
       <ScheduleTimetableModal
         open={timetableOpen}
         onOpenChange={setTimetableOpen}
+        entries={timetableEntries}
+        meta={timetableMeta}
+        isLoading={isTimetableLoading}
+        errorMessage={timetableError}
       />
     </div>
   );

--- a/src/components/common/header/DashbardHeader.tsx
+++ b/src/components/common/header/DashbardHeader.tsx
@@ -32,6 +32,11 @@ export function DashboardHeader() {
   const { user } = useAuthContext();
   const { signout } = useAuth();
   const router = useRouter();
+  const [isMounted, setIsMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   const getRoleLabel = (userType: string) => {
     switch (userType) {
@@ -111,35 +116,52 @@ export function DashboardHeader() {
           </Breadcrumb>
         )}
       </div>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <div className="flex cursor-pointer items-center gap-4">
-            <Avatar className="size-12 border-[1.5px] border-neutral-50 bg-white">
-              <AvatarImage src={user?.image || undefined} alt={displayName} />
-              <AvatarFallback className="bg-neutral-50 text-sm text-neutral-400">
-                {initials}
-              </AvatarFallback>
-            </Avatar>
-            <span className="text-[18px] font-medium leading-[26px] tracking-[-0.18px] text-neutral-400">
-              {displayName}
-            </span>
-          </div>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-50">
-          <DropdownMenuItem
-            onClick={handleProfileClick}
-            className="cursor-pointer"
-          >
-            <User className="mr-2 h-4 w-4" />
-            <span>내 프로필</span>
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={handleLogout} className="cursor-pointer">
-            <LogOut className="mr-2 h-4 w-4" />
-            <span>로그아웃</span>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      {isMounted ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="flex cursor-pointer items-center gap-4"
+            >
+              <Avatar className="size-12 border-[1.5px] border-neutral-50 bg-white">
+                <AvatarImage src={user?.image || undefined} alt={displayName} />
+                <AvatarFallback className="bg-neutral-50 text-sm text-neutral-400">
+                  {initials}
+                </AvatarFallback>
+              </Avatar>
+              <span className="text-[18px] font-medium leading-[26px] tracking-[-0.18px] text-neutral-400">
+                {displayName}
+              </span>
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-50">
+            <DropdownMenuItem
+              onClick={handleProfileClick}
+              className="cursor-pointer"
+            >
+              <User className="mr-2 h-4 w-4" />
+              <span>내 프로필</span>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={handleLogout} className="cursor-pointer">
+              <LogOut className="mr-2 h-4 w-4" />
+              <span>로그아웃</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : (
+        <div className="flex items-center gap-4">
+          <Avatar className="size-12 border-[1.5px] border-neutral-50 bg-white">
+            <AvatarImage src={user?.image || undefined} alt={displayName} />
+            <AvatarFallback className="bg-neutral-50 text-sm text-neutral-400">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+          <span className="text-[18px] font-medium leading-[26px] tracking-[-0.18px] text-neutral-400">
+            {displayName}
+          </span>
+        </div>
+      )}
     </header>
   );
 }

--- a/src/components/common/input/DatePickerField.tsx
+++ b/src/components/common/input/DatePickerField.tsx
@@ -12,9 +12,28 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
+type DatePickerBaseProps = {
+  id?: string;
+  value?: string;
+  onChangeAction: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+};
+
 type DatePickerFieldProps<T extends FieldValues> = {
   control: Control<T>;
   name: Path<T>;
+  id?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+};
+
+type DatePickerInputProps = {
+  id?: string;
+  value?: string;
+  onChangeAction: (value: string) => void;
   placeholder?: string;
   disabled?: boolean;
   className?: string;
@@ -29,16 +48,15 @@ const formatDisplayDate = (date: Date) => {
 
 const formatValueDate = (date: Date) => date.toLocaleDateString("sv-SE");
 
-export function DatePickerField<T extends FieldValues>({
-  control,
-  name,
+function DatePickerBase({
+  id,
+  value,
+  onChangeAction,
   placeholder = "날짜 선택",
   disabled,
   className,
-}: DatePickerFieldProps<T>) {
-  const { field } = useController({ control, name });
+}: DatePickerBaseProps) {
   const [open, setOpen] = useState(false);
-  const value = field.value as string | undefined;
 
   const selectedDate = useMemo(() => {
     if (!value) return undefined;
@@ -52,6 +70,7 @@ export function DatePickerField<T extends FieldValues>({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <button
+          id={id}
           type="button"
           disabled={disabled}
           className={cn(
@@ -71,7 +90,7 @@ export function DatePickerField<T extends FieldValues>({
           selected={selectedDate}
           onSelect={(date) => {
             if (!date) return;
-            field.onChange(formatValueDate(date));
+            onChangeAction(formatValueDate(date));
             setOpen(false);
           }}
           className="eduops-date-picker"
@@ -92,5 +111,47 @@ export function DatePickerField<T extends FieldValues>({
         />
       </PopoverContent>
     </Popover>
+  );
+}
+
+export function DatePickerField<T extends FieldValues>({
+  control,
+  name,
+  id,
+  placeholder = "날짜 선택",
+  disabled,
+  className,
+}: DatePickerFieldProps<T>) {
+  const { field } = useController({ control, name });
+
+  return (
+    <DatePickerBase
+      id={id}
+      value={field.value as string | undefined}
+      onChangeAction={field.onChange}
+      placeholder={placeholder}
+      disabled={disabled}
+      className={className}
+    />
+  );
+}
+
+export function DatePickerInput({
+  id,
+  value,
+  onChangeAction,
+  placeholder = "날짜 선택",
+  disabled,
+  className,
+}: DatePickerInputProps) {
+  return (
+    <DatePickerBase
+      id={id}
+      value={value}
+      onChangeAction={onChangeAction}
+      placeholder={placeholder}
+      disabled={disabled}
+      className={className}
+    />
   );
 }

--- a/src/services/schedules/schedules.mapper.ts
+++ b/src/services/schedules/schedules.mapper.ts
@@ -1,0 +1,200 @@
+import { endOfMonth, endOfWeek, startOfMonth, startOfWeek } from "date-fns";
+import type { View } from "react-big-calendar";
+
+import type {
+  CreateSchedulePayload,
+  FetchSchedulesQuery,
+  ScheduleApi,
+  ScheduleCategoryApi,
+  ScheduleCalendarEvent,
+  ScheduleCategoryOption,
+  ScheduleFormState,
+  UpdateSchedulePayload,
+} from "@/types/schedules";
+
+export const OTHER_CATEGORY_KEY = "other";
+
+const DEFAULT_OTHER_CATEGORY: ScheduleCategoryOption = {
+  id: OTHER_CATEGORY_KEY,
+  name: "기타",
+  color: "#f59e0b",
+};
+
+const KST_TIMEZONE = "Asia/Seoul";
+
+const KST_DATE_TIME_FORMATTER = new Intl.DateTimeFormat("sv-SE", {
+  timeZone: KST_TIMEZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+
+const KST_TIME_LABEL_FORMATTER = new Intl.DateTimeFormat("ko-KR", {
+  timeZone: KST_TIMEZONE,
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+const toUtcIsoFromKstLocal = (date: string, time: string) =>
+  new Date(`${date}T${time}+09:00`).toISOString();
+
+const formatDateToUtcIsoFromKstCalendar = (date: Date) => {
+  const parts = KST_DATE_TIME_FORMATTER.formatToParts(date);
+
+  const getPart = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value ?? "00";
+
+  const year = getPart("year");
+  const month = getPart("month");
+  const day = getPart("day");
+  const hour = getPart("hour");
+  const minute = getPart("minute");
+  const second = getPart("second");
+
+  const kstOffsetDateTime = `${year}-${month}-${day}T${hour}:${minute}:${second}+09:00`;
+
+  return new Date(kstOffsetDateTime).toISOString();
+};
+
+export const normalizeScheduleCategories = (
+  categories: ScheduleCategoryApi[]
+): ScheduleCategoryOption[] => {
+  const normalized = categories.map((category) => ({
+    id: category.id,
+    name: category.name,
+    color: category.color,
+  }));
+
+  const hasOther = normalized.some(
+    (category) => category.id === OTHER_CATEGORY_KEY
+  );
+
+  if (!hasOther) {
+    normalized.push(DEFAULT_OTHER_CATEGORY);
+  }
+
+  return normalized;
+};
+
+export const buildSchedulesRangeQuery = (
+  currentDate: Date,
+  view: View
+): FetchSchedulesQuery => {
+  const startDate =
+    view === "week"
+      ? startOfWeek(currentDate, { weekStartsOn: 0 })
+      : startOfMonth(currentDate);
+  const endDate =
+    view === "week"
+      ? endOfWeek(currentDate, { weekStartsOn: 0 })
+      : endOfMonth(currentDate);
+
+  return {
+    startTime: formatDateToUtcIsoFromKstCalendar(startDate),
+    endTime: formatDateToUtcIsoFromKstCalendar(endDate),
+  };
+};
+
+export const mapScheduleFormToPayload = (
+  formState: ScheduleFormState
+): CreateSchedulePayload => {
+  const startTime = formState.isAllDay
+    ? toUtcIsoFromKstLocal(formState.date, "00:00:00")
+    : toUtcIsoFromKstLocal(formState.date, `${formState.startTime}:00`);
+  const endTime = formState.isAllDay
+    ? toUtcIsoFromKstLocal(formState.date, "23:59:59")
+    : toUtcIsoFromKstLocal(formState.date, `${formState.endTime}:00`);
+
+  return {
+    title: formState.title.trim(),
+    memo: formState.description.trim() || undefined,
+    startTime,
+    endTime,
+    categoryId:
+      formState.categoryId === OTHER_CATEGORY_KEY
+        ? undefined
+        : formState.categoryId,
+  };
+};
+
+export const mapScheduleFormToUpdatePayload = (
+  formState: ScheduleFormState
+): UpdateSchedulePayload => {
+  const startTime = formState.isAllDay
+    ? toUtcIsoFromKstLocal(formState.date, "00:00:00")
+    : toUtcIsoFromKstLocal(formState.date, `${formState.startTime}:00`);
+  const endTime = formState.isAllDay
+    ? toUtcIsoFromKstLocal(formState.date, "23:59:59")
+    : toUtcIsoFromKstLocal(formState.date, `${formState.endTime}:00`);
+
+  return {
+    title: formState.title.trim(),
+    memo: formState.description.trim() || undefined,
+    startTime,
+    endTime,
+    categoryId:
+      formState.categoryId === OTHER_CATEGORY_KEY ? null : formState.categoryId,
+  };
+};
+
+const getCategoryFallback = (
+  schedule: ScheduleApi,
+  categoryMap: Map<string, ScheduleCategoryOption>
+) => {
+  if (!schedule.categoryId) {
+    return DEFAULT_OTHER_CATEGORY;
+  }
+
+  return (
+    categoryMap.get(schedule.categoryId) ?? {
+      id: schedule.categoryId,
+      name: "미분류",
+      color: "#94a3b8",
+    }
+  );
+};
+
+export const mapScheduleApiToCalendarEvent = (
+  schedule: ScheduleApi,
+  categoryMap: Map<string, ScheduleCategoryOption>
+): ScheduleCalendarEvent | null => {
+  const start = new Date(schedule.startTime);
+  const end = new Date(schedule.endTime);
+
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return null;
+  }
+
+  const kstStartLabel = KST_TIME_LABEL_FORMATTER.format(start);
+  const kstEndLabel = KST_TIME_LABEL_FORMATTER.format(end);
+  const isAllDay = kstStartLabel === "00:00" && kstEndLabel === "23:59";
+
+  const category =
+    schedule.category && schedule.categoryId
+      ? {
+          id: schedule.categoryId,
+          name: schedule.category.name,
+          color: schedule.category.color,
+        }
+      : getCategoryFallback(schedule, categoryMap);
+
+  return {
+    id: schedule.id,
+    title: isAllDay ? schedule.title : `${kstStartLabel} ${schedule.title}`,
+    name: schedule.title,
+    start,
+    end,
+    allDay: isAllDay,
+    categoryId: schedule.categoryId ?? null,
+    categoryKey: schedule.categoryId ?? OTHER_CATEGORY_KEY,
+    categoryName: category.name,
+    categoryColor: category.color,
+    description: schedule.memo ?? undefined,
+    timeLabel: isAllDay ? "종일" : `${kstStartLabel} - ${kstEndLabel}`,
+  };
+};

--- a/src/services/schedules/schedules.service.ts
+++ b/src/services/schedules/schedules.service.ts
@@ -1,0 +1,108 @@
+import { axiosClient } from "@/services/axiosClient";
+import type { ApiResponse } from "@/types/api";
+import type {
+  CreateScheduleCategoryPayload,
+  CreateSchedulePayload,
+  FetchSchedulesQuery,
+  ScheduleApi,
+  ScheduleCategoryApi,
+  UpdateSchedulePayload,
+  UpdateScheduleCategoryPayload,
+} from "@/types/schedules";
+
+export const fetchSchedulesAPI = async (
+  query: FetchSchedulesQuery
+): Promise<ScheduleApi[]> => {
+  const { data } = await axiosClient.get<ApiResponse<ScheduleApi[]>>(
+    "/schedules",
+    {
+      params: query,
+    }
+  );
+
+  return data.data ?? [];
+};
+
+export const fetchScheduleCategoriesAPI = async (): Promise<
+  ScheduleCategoryApi[]
+> => {
+  const { data } = await axiosClient.get<ApiResponse<ScheduleCategoryApi[]>>(
+    "/schedule-categories"
+  );
+
+  return data.data ?? [];
+};
+
+export const createScheduleAPI = async (
+  payload: CreateSchedulePayload
+): Promise<ScheduleApi> => {
+  const { data } = await axiosClient.post<ApiResponse<ScheduleApi>>(
+    "/schedules",
+    payload
+  );
+
+  if (!data?.data) {
+    throw new Error("일정 생성 결과가 비어 있습니다.");
+  }
+
+  return data.data;
+};
+
+export const updateScheduleAPI = async (
+  scheduleId: string,
+  payload: UpdateSchedulePayload
+): Promise<ScheduleApi> => {
+  const { data } = await axiosClient.patch<ApiResponse<ScheduleApi>>(
+    `/schedules/${scheduleId}`,
+    payload
+  );
+
+  if (!data?.data) {
+    throw new Error("일정 수정 결과가 비어 있습니다.");
+  }
+
+  return data.data;
+};
+
+export const deleteScheduleAPI = async (scheduleId: string): Promise<void> => {
+  await axiosClient.delete<ApiResponse<void>>(`/schedules/${scheduleId}`);
+};
+
+export const createScheduleCategoryAPI = async (
+  payload: CreateScheduleCategoryPayload
+): Promise<ScheduleCategoryApi> => {
+  const { data } = await axiosClient.post<ApiResponse<ScheduleCategoryApi>>(
+    "/schedule-categories",
+    payload
+  );
+
+  if (!data?.data) {
+    throw new Error("카테고리 생성 결과가 비어 있습니다.");
+  }
+
+  return data.data;
+};
+
+export const updateScheduleCategoryAPI = async (
+  categoryId: string,
+  payload: UpdateScheduleCategoryPayload
+): Promise<ScheduleCategoryApi> => {
+  const { data } = await axiosClient.patch<ApiResponse<ScheduleCategoryApi>>(
+    `/schedule-categories/${categoryId}`,
+    payload
+  );
+
+  if (!data?.data) {
+    throw new Error("카테고리 수정 결과가 비어 있습니다.");
+  }
+
+  return data.data;
+};
+
+export const deleteScheduleCategoryAPI = async (
+  categoryId: string
+): Promise<void> => {
+  await axiosClient.delete<ApiResponse<void>>(
+    `/schedule-categories/${categoryId}`
+  );
+};

--- a/src/types/lectures/lectures-api.ts
+++ b/src/types/lectures/lectures-api.ts
@@ -64,6 +64,7 @@ export type LecturesPagination = {
 export type LectureApi = {
   id: string;
   title: string;
+  color?: string | null;
   schoolYear?: string | null;
   subject?: string | null;
   description?: string | null;

--- a/src/types/schedules/index.ts
+++ b/src/types/schedules/index.ts
@@ -1,0 +1,2 @@
+export * from "./schedules";
+export * from "./schedules-api";

--- a/src/types/schedules/schedules-api.ts
+++ b/src/types/schedules/schedules-api.ts
@@ -1,0 +1,49 @@
+export type ScheduleCategoryApi = {
+  id: string;
+  name: string;
+  color: string;
+};
+
+export type ScheduleApi = {
+  id: string;
+  title: string;
+  memo?: string | null;
+  startTime: string;
+  endTime: string;
+  categoryId?: string | null;
+  category?: ScheduleCategoryApi | null;
+  createdAt?: string;
+  updatedAt?: string | null;
+};
+
+export type FetchSchedulesQuery = {
+  startTime: string;
+  endTime: string;
+  category?: string;
+};
+
+export type CreateSchedulePayload = {
+  title: string;
+  memo?: string;
+  startTime: string;
+  endTime: string;
+  categoryId?: string;
+};
+
+export type UpdateSchedulePayload = {
+  title?: string;
+  memo?: string;
+  startTime?: string;
+  endTime?: string;
+  categoryId?: string | null;
+};
+
+export type CreateScheduleCategoryPayload = {
+  name: string;
+  color: string;
+};
+
+export type UpdateScheduleCategoryPayload = {
+  name?: string;
+  color?: string;
+};

--- a/src/types/schedules/schedules.ts
+++ b/src/types/schedules/schedules.ts
@@ -1,0 +1,67 @@
+export type ScheduleCategoryOption = {
+  id: string;
+  name: string;
+  color: string;
+};
+
+export type ScheduleCalendarEvent = {
+  id: string;
+  title: string;
+  name: string;
+  start: Date;
+  end: Date;
+  allDay?: boolean;
+  categoryId: string | null;
+  categoryKey: string;
+  categoryName: string;
+  categoryColor: string;
+  description?: string;
+  timeLabel: string;
+};
+
+export type ScheduleFormState = {
+  title: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  isAllDay: boolean;
+  categoryId: string;
+  description: string;
+};
+
+export type ScheduleModalMode = "create" | "view" | "edit";
+
+export type ScheduleCategoryCreateState = {
+  name: string;
+  color: string;
+};
+
+export type ScheduleCategoryEditState = {
+  name: string;
+  color: string;
+};
+
+export type ScheduleFilters = Record<string, boolean>;
+
+export type ScheduleTimetableDay =
+  | "월"
+  | "화"
+  | "수"
+  | "목"
+  | "금"
+  | "토"
+  | "일";
+
+export type ScheduleTimetableEntry = {
+  id: string;
+  title: string;
+  day: ScheduleTimetableDay;
+  startTime: string;
+  endTime: string;
+  color: string;
+};
+
+export type ScheduleTimetableMeta = {
+  academy: string;
+  term: string;
+};


### PR DESCRIPTION
🔗 관련 이슈
- Closes #126
 ✨ 작업 단계 및 변경 사항
- **작업 단계:** Phase 1(기능 구현) + Phase 2(디자인/UX 및 API 연동)

- **변경 사항:**
  - 스케줄 관리(G0) 전체를 mock 중심에서 API 중심으로 전환
    - schedules 타입/서비스/매퍼 정리
    - 일정 생성/수정/삭제 FE 연결
    - 카테고리 생성/수정/삭제 FE 연결
  - 일정 모달 정책 개선
    - `create / view / edit` 모드 분리
    - 확인(view) 모드에서 수정 버튼으로 활성화
    - 삭제 버튼은 수정(edit) 모드에서만 노출
  - 시간표 모달(G0-2) 실데이터 연동
    - lectures API 기반 렌더링으로 전환
    - 시간표 색상: `lecture.color` 우선, 없으면 `lecture.id` 기반 deterministic fallback
    - 고정 시간축(08~24) 제거, 데이터 기반 동적 시간축(min/max + padding + clamp) 적용
  - 카테고리 삭제 안정화
    - 연관 일정을 `other`(categoryId: null)로 자동 이관 후 삭제
    - 이관 API 호출을 배치 처리(동시성 제한)로 변경
    - 부분 실패 시 삭제 중단 및 에러 메시지 노출
  - 일정 입력 UX 개선
    - 일정 날짜: 기존 커스텀 DatePicker 패턴 적용
    - 시간 입력: 시작/종료 분리 + 키보드 직접 입력(`HH:mm` 자동 정규화)
    - 시작/종료 AM/PM 배지 강조
    - 종일 일정 토글 UI를 날짜 카드 내부 인라인 컴팩트 형태로 정리
  - 사이드바 개선
    - "전체 일정 보기" 제거
    - "다가오는 일정(오늘)" 카드 클릭 시 편집 모달 진입
    - 시간 라벨 `시작 - 종료` 형식으로 표기


 🧪 테스트 방법
- 리뷰어가 확인해야 할 핵심 포인트:

- [ ] `/educators/schedules` 페이지가 정상 렌더링되는가?
- [ ] 일정 생성 시 날짜/시작시간/종료시간 입력 후 저장이 정상 동작하는가?
- [ ] 일정 클릭 시 `일정 확인` 모달이 열리고, `수정` 클릭 후에만 편집 가능한가?
- [ ] 수정 모드에서만 삭제 버튼이 보이고 실제 삭제가 가능한가?
- [ ] 카테고리 삭제 시 연결 일정이 `기타`로 이관되고 삭제가 완료되는가?
- [ ] 시간표 보기 모달이 lectures 실데이터를 렌더링하는가?
- [ ] 시간표 축이 데이터에 따라 동적으로 줄어들거나 확장되는가?
- [ ] "다가오는 일정(오늘)" 카드에서 시간이 `시작 - 종료`로 보이는가?

## 📸 스크린샷 (선택)
<img width="1733" height="964" alt="스크린샷 2026-02-12 00 44 28" src="https://github.com/user-attachments/assets/ee15fc9f-48b7-49f4-bec6-85ab47e48f35" />
<img width="564" height="787" alt="스크린샷 2026-02-12 00 44 45" src="https://github.com/user-attachments/assets/cbbd3b3b-7280-44d5-bec4-89c4a565cef4" />


<img width="1115" height="960" alt="스크린샷 2026-02-12 00 44 57" src="https://github.com/user-attachments/assets/17cb6ca9-dc26-4028-a512-7310cda97a4b" />
<img width="628" height="543" alt="스크린샷 2026-02-12 00 45 05" src="https://github.com/user-attachments/assets/3fbb0744-8c38-408e-b795-fef2069abd9f" />


## ✅ 체크리스트

- [ ] `Phase`에 맞는 이슈 체크리스트를 모두 완료했는가?
- [ ] lint / type-check 통과 및 불필요한 console.log 제거
- [ ] **머지 후 이 이슈가 [QA] 컬럼으로 이동함을 인지하고 있는가?**

## 워크로그
[2026-02-11_G0-page-api-worklog.md](https://github.com/user-attachments/files/25239225/2026-02-11_G0-page-api-worklog.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added schedule category management (create, edit, delete categories with custom colors)
  * Enhanced schedule creation with separate start/end times, all-day event toggle, and category selection
  * Implemented timetable visualization with dynamic time axis and flexible layout
  * Added schedule view and edit modes with delete functionality
  * Introduced category filtering for schedule display
  * Added schedule description field

* **Improvements**
  * Optimized calendar view performance with memoization
  * Fixed header dropdown menu hydration issues
  * Enhanced date picker with new input component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->