### PR TITLE
Refactor yr/second qa

### DIFF
--- a/src/app/(dashboard)/educators/communication/[communicationId]/_components/PostComment.tsx
+++ b/src/app/(dashboard)/educators/communication/[communicationId]/_components/PostComment.tsx
@@ -1,5 +1,5 @@
 import { Edit, Trash2, X, Paperclip, Save } from "lucide-react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { JSONContent } from "@tiptap/react";
 import Image from "next/image";
 
@@ -23,8 +23,6 @@ type PostCommentProps = {
   setAnswerContent: (val: JSONContent) => void;
   selectedFile: File | null;
   setSelectedFile: (file: File | null) => void;
-  fileInputRef: React.RefObject<HTMLInputElement>;
-  handleFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   handleSubmitAnswer: () => void;
   onUpdateComment: (
     commentId: string,
@@ -42,8 +40,6 @@ export default function PostComment({
   setAnswerContent,
   selectedFile,
   setSelectedFile,
-  fileInputRef,
-  handleFileChange,
   handleSubmitAnswer,
   onUpdateComment,
   onDeleteComment,
@@ -114,18 +110,13 @@ export default function PostComment({
               </div>
             )}
 
-            <div className="flex items-center justify-between pt-2">
-              <div className="flex items-center gap-2">
-                <input
-                  type="file"
-                  ref={fileInputRef}
-                  onChange={handleFileChange}
-                  className="hidden"
-                />
-              </div>
+            <div className="flex items-start justify-between">
+              <p className="text-[11px] text-slate-400 px-1">
+                * 이미지 파일만 첨부할 수 있습니다.
+              </p>
               <Button
                 onClick={handleSubmitAnswer}
-                className="h-14 w-[140px] gap-2.5 rounded-xl border border-[#3863f6] bg-[#3863f6] px-0 text-base font-semibold tracking-[-0.01em] text-white shadow-[0_0_14px_rgba(138,138,138,0.08)] hover:bg-[#2f57e8] cursor-pointer"
+                className="h-14 w-[140px] gap-1 rounded-xl border border-[#3863f6] bg-[#3863f6] px-0 text-base font-semibold tracking-[-0.01em] text-white shadow-[0_0_14px_rgba(138,138,138,0.08)] hover:bg-[#2f57e8] cursor-pointer"
               >
                 {isNoticePost ? "댓글 등록" : "답변 등록"}
               </Button>
@@ -173,7 +164,6 @@ function CommentItem({
   );
   const [editFile, setEditFile] = useState<File | null>(null);
   const [removeExistingImage, setRemoveExistingImage] = useState(false);
-  const editFileInputRef = useRef<HTMLInputElement>(null);
 
   const images =
     comment.attachments?.filter((f) =>
@@ -302,76 +292,14 @@ function CommentItem({
           <TiptapEditor
             content={editContent}
             onChange={setEditContent}
+            onFileUpload={(file) => {
+              setEditFile(file);
+              setRemoveExistingImage(false);
+            }}
+            attachment={editFile}
+            onRemoveAttachment={() => setEditFile(null)}
             className="min-h-[120px] border-blue-100 shadow-sm"
           />
-          {/* 파일 선택 UI */}
-          <div className="mt-2 flex flex-wrap items-center gap-2">
-            <input
-              type="file"
-              accept="image/*"
-              ref={editFileInputRef}
-              onChange={(e) => {
-                setEditFile(e.target.files?.[0] ?? null);
-                // 새 파일 선택 시 삭제 플래그 해제
-                if (e.target.files?.[0]) setRemoveExistingImage(false);
-              }}
-              className="hidden"
-            />
-            {editFile ? (
-              <div className="p-2 bg-slate-50 border rounded-lg flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Paperclip className="h-4 w-4 text-blue-500" />
-                  <span className="text-sm text-slate-700 truncate max-w-[200px]">
-                    {editFile.name}
-                  </span>
-                </div>
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    setEditFile(null);
-                    if (editFileInputRef.current)
-                      editFileInputRef.current.value = "";
-                  }}
-                  className="h-7 w-7 p-0 hover:text-red-500"
-                >
-                  <X className="h-3 w-3" />
-                </Button>
-              </div>
-            ) : (
-              <Button
-                variant="outline"
-                onClick={() => editFileInputRef.current?.click()}
-                className="gap-2 text-slate-500 h-8 px-3 text-sm"
-              >
-                <Paperclip className="h-4 w-4" />
-                이미지 교체
-              </Button>
-            )}
-            {/* 기존 이미지가 있고 새 파일 미선택 시 삭제 버튼 표시 */}
-            {images.length > 0 &&
-              !editFile &&
-              (removeExistingImage ? (
-                <Button
-                  variant="outline"
-                  onClick={() => setRemoveExistingImage(false)}
-                  className="gap-2 text-blue-500 h-8 px-3 text-sm"
-                >
-                  이미지 복원
-                </Button>
-              ) : (
-                <Button
-                  variant="outline"
-                  onClick={() => setRemoveExistingImage(true)}
-                  className="gap-2 text-red-500 hover:text-red-600 h-8 px-3 text-sm"
-                >
-                  <X className="h-4 w-4" />
-                  이미지 삭제
-                </Button>
-              ))}
-          </div>
-          <p className="text-[10px] text-slate-400 mt-1">
-            내용 수정 후 상단의 체크 버튼을 눌러주세요.
-          </p>
         </div>
       ) : (
         <TiptapEditor
@@ -383,11 +311,40 @@ function CommentItem({
 
       {images.length > 0 &&
         (isEditing && removeExistingImage ? (
-          <div className="px-2 mt-2 py-3 border border-dashed border-red-200 rounded-lg bg-red-50/50 text-center text-sm text-red-400">
-            저장 시 이미지가 삭제됩니다
+          <div className="mt-4">
+            <div className="rounded-xl border-2 border-dashed p-4 transition-colors bg-white border-slate-100 relative">
+              <div className="py-8 flex flex-col items-center justify-center space-y-2">
+                <div className="p-3 bg-slate-50 rounded-full">
+                  <Paperclip className="h-6 w-6 text-slate-300" />
+                </div>
+                <p className="text-sm text-slate-400">
+                  이미지만 첨부할 수 있습니다.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setRemoveExistingImage(false)}
+                className="absolute top-2 right-2 h-8 w-8 p-0 rounded-full hover:bg-red-50 hover:text-red-500"
+                title="복원"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
           </div>
-        ) : (
-          <div className="px-2 mt-2 space-y-3">
+        ) : isEditing && editFile ? null : (
+          <div className="mt-4 space-y-3 relative">
+            {isEditing && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setRemoveExistingImage(true)}
+                className="absolute top-2 right-2 z-10 h-8 w-8 p-0 rounded-full bg-white/95 hover:bg-red-50 hover:text-red-600 border shadow-sm"
+                title="삭제"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            )}
             {images.map((img) => (
               <div
                 key={img.id || img.filename}

--- a/src/app/(dashboard)/educators/communication/[communicationId]/_components/PostComment.tsx
+++ b/src/app/(dashboard)/educators/communication/[communicationId]/_components/PostComment.tsx
@@ -327,6 +327,7 @@ function CommentItem({
                 onClick={() => setRemoveExistingImage(false)}
                 className="absolute top-2 right-2 h-8 w-8 p-0 rounded-full hover:bg-red-50 hover:text-red-500"
                 title="복원"
+                aria-label="첨부 이미지 복원"
               >
                 <X className="h-4 w-4" />
               </Button>
@@ -341,6 +342,7 @@ function CommentItem({
                 onClick={() => setRemoveExistingImage(true)}
                 className="absolute top-2 right-2 z-10 h-8 w-8 p-0 rounded-full bg-white/95 hover:bg-red-50 hover:text-red-600 border shadow-sm"
                 title="삭제"
+                aria-label="첨부 이미지 삭제"
               >
                 <X className="h-4 w-4" />
               </Button>

--- a/src/app/(dashboard)/educators/communication/[communicationId]/_components/PostInfo.tsx
+++ b/src/app/(dashboard)/educators/communication/[communicationId]/_components/PostInfo.tsx
@@ -108,9 +108,9 @@ export default function PostInfo({
                       <div className="flex flex-wrap gap-x-1.5 gap-y-1">
                         {noticePostData?.targets &&
                         noticePostData.targets.length > 0 ? (
-                          noticePostData.targets.map((target) => (
+                          noticePostData.targets.map((target, index) => (
                             <span
-                              key={target.id}
+                              key={`${target.id}-${index}`}
                               className="text-[14px] font-semibold text-slate-700"
                             >
                               {target.enrollment.studentName}

--- a/src/app/(dashboard)/educators/communication/[communicationId]/_components/PostInfo.tsx
+++ b/src/app/(dashboard)/educators/communication/[communicationId]/_components/PostInfo.tsx
@@ -50,6 +50,10 @@ export default function PostInfo({
   const isInProgress = workStatus === "IN_PROGRESS";
   const isEnd = workStatus === "END";
 
+  const isImportant = noticePostData?.isImportant;
+  const noticeLabel = isImportant ? "공지" : "자료";
+  const noticeColor = isImportant ? "blue" : "green";
+
   return (
     <Card className="border shadow-sm">
       <CardContent className="p-0">
@@ -72,7 +76,7 @@ export default function PostInfo({
                 </Label>
                 <div className="mt-1">
                   {isNoticePost ? (
-                    <StatusLabel color="blue">공지</StatusLabel>
+                    <StatusLabel color={noticeColor}>{noticeLabel}</StatusLabel>
                   ) : isWorksPost ? (
                     <StatusLabel color="blue">업무</StatusLabel>
                   ) : (

--- a/src/app/(dashboard)/educators/communication/[communicationId]/_components/PostInfo.tsx
+++ b/src/app/(dashboard)/educators/communication/[communicationId]/_components/PostInfo.tsx
@@ -95,13 +95,35 @@ export default function PostInfo({
                   <Label className="text-xs text-slate-400 font-medium">
                     수신 대상
                   </Label>
-                  <p className="mt-0.5 text-[14px] font-semibold text-slate-700">
-                    {noticePostData?.scope === "GLOBAL"
-                      ? "전체 클래스"
-                      : noticePostData?.scope === "LECTURE"
-                        ? "특정 클래스"
-                        : "특정 학생"}
-                  </p>
+                  <div className="mt-0.5 flex flex-wrap gap-1">
+                    {noticePostData?.scope === "GLOBAL" ? (
+                      <p className="text-[14px] font-semibold text-slate-700">
+                        전체 클래스
+                      </p>
+                    ) : noticePostData?.scope === "LECTURE" ? (
+                      <p className="text-[14px] font-semibold text-slate-700">
+                        특정 클래스
+                      </p>
+                    ) : (
+                      <div className="flex flex-wrap gap-x-1.5 gap-y-1">
+                        {noticePostData?.targets &&
+                        noticePostData.targets.length > 0 ? (
+                          noticePostData.targets.map((target) => (
+                            <span
+                              key={target.id}
+                              className="text-[14px] font-semibold text-slate-700"
+                            >
+                              {target.enrollment.studentName}
+                            </span>
+                          ))
+                        ) : (
+                          <span className="text-[14px] font-semibold text-slate-700">
+                            대상 없음
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
                 </div>
               </div>
             )}

--- a/src/app/(dashboard)/educators/communication/[communicationId]/page.tsx
+++ b/src/app/(dashboard)/educators/communication/[communicationId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState } from "react";
 import { useRouter, useParams, useSearchParams } from "next/navigation";
 import { JSONContent } from "@tiptap/react";
 
@@ -39,7 +39,6 @@ export default function CommunicationDetailPage() {
   const searchParams = useSearchParams();
   const communicationId = params.communicationId as string;
   const type = searchParams.get("type") as "notice" | "inquiry" | "works";
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const { showAlert } = useDialogAlert();
   const { openModal } = useModal();
 
@@ -219,7 +218,6 @@ export default function CommunicationDetailPage() {
     const handleSuccess = () => {
       setAnswerContent({});
       setSelectedFile(null);
-      if (fileInputRef.current) fileInputRef.current.value = "";
     };
 
     const formData = new FormData();
@@ -301,12 +299,6 @@ export default function CommunicationDetailPage() {
         }}
       />
     );
-  };
-
-  // 자료 변경
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) setSelectedFile(file);
   };
 
   // 자료 다운로드
@@ -445,8 +437,6 @@ export default function CommunicationDetailPage() {
               setAnswerContent={setAnswerContent}
               selectedFile={selectedFile}
               setSelectedFile={setSelectedFile}
-              fileInputRef={fileInputRef as React.RefObject<HTMLInputElement>}
-              handleFileChange={handleFileChange}
               handleSubmitAnswer={handleSubmitAnswer}
               onUpdateComment={handleUpdateComment}
               onDeleteComment={handleDeleteComment}

--- a/src/app/(dashboard)/educators/communication/[communicationId]/page.tsx
+++ b/src/app/(dashboard)/educators/communication/[communicationId]/page.tsx
@@ -354,23 +354,24 @@ export default function CommunicationDetailPage() {
 
   return (
     <div className="container mx-auto space-y-8 p-6">
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <Title
-          title={
-            isNoticePost
-              ? "공지사항 상세"
-              : isWorksPost
-                ? "조교 업무 상세"
-                : "문의 상세"
-          }
-          description={
-            isEditing
-              ? "게시글을 수정 중입니다."
-              : isWorksPost
-                ? "업무의 상세 내용을 확인하세요."
-                : "게시글의 상세 내용을 확인하세요."
-          }
-        />
+      <Title
+        title={
+          isNoticePost
+            ? "공지사항 상세"
+            : isWorksPost
+              ? "조교 업무 상세"
+              : "문의 상세"
+        }
+        description={
+          isEditing
+            ? "게시글을 수정 중입니다."
+            : isWorksPost
+              ? "업무의 상세 내용을 확인하세요."
+              : "게시글의 상세 내용을 확인하세요."
+        }
+      />
+
+      <div className="flex items-center justify-end">
         <PostAction
           isEditing={isEditing}
           isMine={

--- a/src/app/(dashboard)/educators/communication/_components/filter/TabSection.tsx
+++ b/src/app/(dashboard)/educators/communication/_components/filter/TabSection.tsx
@@ -49,7 +49,7 @@ export default function TabSection() {
 
   // 검색어 상태 및 디바운스
   const [searchTerm, setSearchTerm] = useState("");
-  const debouncedSearchTerm = useDebounce(searchTerm, 500);
+  const debouncedSearchTerm = useDebounce(searchTerm, 300);
 
   // 요청 쿼리
   const [query, setQuery] = useState<PostFilterQuery>({

--- a/src/app/(dashboard)/educators/communication/_components/table/NoticeTableColumns.tsx
+++ b/src/app/(dashboard)/educators/communication/_components/table/NoticeTableColumns.tsx
@@ -2,7 +2,6 @@ import StatusLabel from "@/components/common/label/StatusLabel";
 import { GetInstructorPostsResponse } from "@/types/communication/instructorPost";
 import { ColumnDefinition } from "@/components/common/table/DataTable";
 import { formatYMDFromISO } from "@/utils/date";
-import { NOTICE_TYPE_LABEL } from "@/constants/communication.default";
 
 type NoticeRow = GetInstructorPostsResponse["list"][number];
 
@@ -24,7 +23,7 @@ export const NOTICE_POST_COLUMNS: ColumnDefinition<NoticeRow>[] = [
     render: (row) => {
       const commentCount = row._count.comments;
       return (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 w-[350px] min-w-0">
           <span className="max-w-[350px] truncate font-medium">
             {row.title}
           </span>
@@ -52,14 +51,19 @@ export const NOTICE_POST_COLUMNS: ColumnDefinition<NoticeRow>[] = [
     key: "authorRole",
     label: "열람 권한",
     render: (row) => {
-      const info =
-        NOTICE_TYPE_LABEL[row.targetRole as keyof typeof NOTICE_TYPE_LABEL] ??
-        NOTICE_TYPE_LABEL.ALL;
-
+      const role = row.targetRole;
       return (
-        <div className="w-[50px] flex items-center">
-          <StatusLabel noBackground color={info.color}>
-            {info.label}
+        <div className="flex items-center gap-1">
+          <StatusLabel color={"gray"} noBackground={role !== "ALL"}>
+            전체
+          </StatusLabel>
+          <p className="text-xs text-slate-500">/</p>
+          <StatusLabel color={"gray"} noBackground={role !== "STUDENT"}>
+            학생
+          </StatusLabel>
+          <p className="text-xs text-slate-500">/</p>
+          <StatusLabel color={"gray"} noBackground={role !== "PARENT"}>
+            학부모
           </StatusLabel>
         </div>
       );

--- a/src/app/(dashboard)/educators/communication/create/_components/modal/AddResourceModal.tsx
+++ b/src/app/(dashboard)/educators/communication/create/_components/modal/AddResourceModal.tsx
@@ -35,7 +35,7 @@ export default function AddResourceModal({
 }: AddResourceModalProps) {
   const { isOpen, closeModal } = useModal();
   const [searchKeyword, setSearchKeyword] = useState("");
-  const debouncedSearch = useDebounce(searchKeyword, 500);
+  const debouncedSearch = useDebounce(searchKeyword, 300);
   const [categoryFilter, setCategoryFilter] = useState("ALL");
   const [tempSelected, setTempSelected] =
     useState<Materials[]>(initialSelected);

--- a/src/app/(dashboard)/educators/students/[studentId]/_components/detail-modal/EditProfileModal.tsx
+++ b/src/app/(dashboard)/educators/students/[studentId]/_components/detail-modal/EditProfileModal.tsx
@@ -25,6 +25,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { InputForm } from "@/components/common/input/InputForm";
 import SelectBtn from "@/components/common/button/SelectBtn";
 import { useDialogAlert } from "@/hooks/useDialogAlert";
+import { formatYMDFromISO } from "@/utils/date";
 
 type EditProfileModalProps = {
   studentData: EditProfileFormDataType;
@@ -39,6 +40,8 @@ const getFormDataOnly = (
     schoolYear: data.schoolYear ?? "",
     studentPhone: data.studentPhone ?? "",
     parentPhone: data.parentPhone ?? "",
+    registeredAt:
+      formatYMDFromISO(data.registeredAt) ?? data.registeredAt ?? "",
     memo: data.memo ?? "",
   };
 };
@@ -110,7 +113,7 @@ export default function EditProfileModal({
   };
 
   const handleClose = () => {
-    reset(studentData); // 변경사항 초기화
+    reset(getFormDataOnly(studentData)); // 변경사항 초기화
     setIsEditMode(false);
     closeModal();
   };
@@ -124,7 +127,7 @@ export default function EditProfileModal({
       open={isOpen}
       onOpenChange={(open) => {
         if (!open) {
-          reset(studentData);
+          reset(getFormDataOnly(studentData));
           setIsEditMode(false);
           closeModal();
         }
@@ -241,6 +244,23 @@ export default function EditProfileModal({
                     setValue("parentPhone", "", { shouldDirty: true })
                   }
                   showReset={isEditMode && !!watchedParentPhone}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="registeredAt" className="text-muted-foreground">
+                  학생 등록일
+                </Label>
+                <InputForm
+                  id="registeredAt"
+                  label="학생 등록일"
+                  {...register("registeredAt")}
+                  type="date"
+                  placeholder="등록일 선택"
+                  disabled={!isEditMode}
+                  floating={false}
+                  className="bg-white border border-neutral-200 rounded-[12px]"
+                  error={errors.registeredAt?.message}
                 />
               </div>
 

--- a/src/app/(dashboard)/educators/students/[studentId]/_components/detail-modal/EditProfileModal.tsx
+++ b/src/app/(dashboard)/educators/students/[studentId]/_components/detail-modal/EditProfileModal.tsx
@@ -24,8 +24,7 @@ import { GRADE_SELECTING_OPTIONS } from "@/constants/students.default";
 import { Textarea } from "@/components/ui/textarea";
 import { InputForm } from "@/components/common/input/InputForm";
 import SelectBtn from "@/components/common/button/SelectBtn";
-import { useDialogAlert } from "@/hooks/useDialogAlert";
-import { formatYMDFromISO } from "@/utils/date";
+import { formatYMDFromISO, toISOFromYMD } from "@/utils/date";
 
 type EditProfileModalProps = {
   studentData: EditProfileFormDataType;
@@ -51,7 +50,6 @@ export default function EditProfileModal({
 }: EditProfileModalProps) {
   const { isOpen, closeModal } = useModal();
   const [isEditMode, setIsEditMode] = useState(false);
-  const { showAlert } = useDialogAlert();
 
   // 수강생 정보 수정
   const { mutate: updateStudent, isPending } = useUpdateEnrollment();
@@ -86,7 +84,12 @@ export default function EditProfileModal({
     // dirtyFields 기준으로 변경된 데이터만 추출
     const changedData = Object.keys(dirtyFields).reduce((acc, key) => {
       const field = key as keyof EditProfileFormData;
-      acc[field] = data[field];
+      let value = data[field];
+      // registeredAt: YYYY-MM-DD → ISO 8601
+      if (field === "registeredAt" && typeof value === "string") {
+        value = toISOFromYMD(value) as EditProfileFormData["registeredAt"];
+      }
+      acc[field] = value;
       return acc;
     }, {} as Partial<EditProfileFormData>);
 
@@ -96,20 +99,7 @@ export default function EditProfileModal({
       return;
     }
 
-    updateStudent(
-      { id: studentData.id, data: changedData },
-      {
-        onSuccess: () => {
-          console.log("수강생 정보 수정 성공:", changedData);
-
-          setIsEditMode(false);
-          closeModal();
-        },
-        onError: async () => {
-          await showAlert({ description: "수강생 정보 수정에 실패했습니다." });
-        },
-      }
-    );
+    updateStudent({ id: studentData.id, data: changedData });
   };
 
   const handleClose = () => {

--- a/src/app/(dashboard)/educators/students/[studentId]/_components/detail-modal/EditProfileModal.tsx
+++ b/src/app/(dashboard)/educators/students/[studentId]/_components/detail-modal/EditProfileModal.tsx
@@ -87,7 +87,11 @@ export default function EditProfileModal({
       let value = data[field];
       // registeredAt: YYYY-MM-DD → ISO 8601
       if (field === "registeredAt" && typeof value === "string") {
-        value = toISOFromYMD(value) as EditProfileFormData["registeredAt"];
+        const normalized = value.trim();
+        if (!normalized) {
+          return acc;
+        }
+        value = toISOFromYMD(normalized) as EditProfileFormData["registeredAt"];
       }
       acc[field] = value;
       return acc;

--- a/src/app/(dashboard)/educators/students/page.tsx
+++ b/src/app/(dashboard)/educators/students/page.tsx
@@ -41,7 +41,7 @@ export default function StudentsListPage() {
 
   // 검색어
   const [searchTerm, setSearchTerm] = useState("");
-  const debouncedSearchTerm = useDebounce(searchTerm, 500);
+  const debouncedSearchTerm = useDebounce(searchTerm, 300);
 
   // 체크박스 스토어
   const {

--- a/src/app/(dashboard)/learners/communication/[communicationId]/_components/PostCommentSVC.tsx
+++ b/src/app/(dashboard)/learners/communication/[communicationId]/_components/PostCommentSVC.tsx
@@ -1,5 +1,5 @@
 import { Edit, Trash2, X, Paperclip, Save } from "lucide-react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { JSONContent } from "@tiptap/react";
 import Image from "next/image";
 
@@ -23,8 +23,6 @@ type PostCommentSVCProps = {
   setAnswerContent: (val: JSONContent) => void;
   selectedFile: File | null;
   setSelectedFile: (file: File | null) => void;
-  fileInputRef: React.RefObject<HTMLInputElement>;
-  handleFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   handleSubmitAnswer: () => void;
   onUpdateComment: (
     commentId: string,
@@ -42,8 +40,6 @@ export default function PostCommentSVC({
   setAnswerContent,
   selectedFile,
   setSelectedFile,
-  fileInputRef,
-  handleFileChange,
   handleSubmitAnswer,
   onUpdateComment,
   onDeleteComment,
@@ -115,18 +111,13 @@ export default function PostCommentSVC({
                 </div>
               )}
 
-              <div className="flex items-center justify-between pt-2">
-                <div className="flex items-center gap-2">
-                  <input
-                    type="file"
-                    ref={fileInputRef}
-                    onChange={handleFileChange}
-                    className="hidden"
-                  />
-                </div>
+              <div className="flex items-start justify-between">
+                <p className="text-[11px] text-slate-400 px-1">
+                  * 이미지 파일만 첨부할 수 있습니다.
+                </p>
                 <Button
                   onClick={handleSubmitAnswer}
-                  className="h-14 w-[140px] gap-2.5 rounded-xl border border-[#3863f6] bg-[#3863f6] px-0 text-base font-semibold tracking-[-0.01em] text-white shadow-[0_0_14px_rgba(138,138,138,0.08)] hover:bg-[#2f57e8] cursor-pointer"
+                  className="h-14 w-[140px] gap-1 rounded-xl border border-[#3863f6] bg-[#3863f6] px-0 text-base font-semibold tracking-[-0.01em] text-white shadow-[0_0_14px_rgba(138,138,138,0.08)] hover:bg-[#2f57e8] cursor-pointer"
                 >
                   {isNoticePost ? "댓글 등록" : "답변 등록"}
                 </Button>
@@ -176,7 +167,6 @@ function CommentItemSVC({
   );
   const [editFile, setEditFile] = useState<File | null>(null);
   const [removeExistingImage, setRemoveExistingImage] = useState(false);
-  const editFileInputRef = useRef<HTMLInputElement>(null);
 
   const images =
     comment.attachments?.filter((f) =>
@@ -305,76 +295,14 @@ function CommentItemSVC({
           <TiptapEditor
             content={editContent}
             onChange={setEditContent}
+            onFileUpload={(file) => {
+              setEditFile(file);
+              setRemoveExistingImage(false);
+            }}
+            attachment={editFile}
+            onRemoveAttachment={() => setEditFile(null)}
             className="min-h-[120px] border-blue-100 shadow-sm"
           />
-          {/* 파일 선택 UI */}
-          <div className="mt-2 flex flex-wrap items-center gap-2">
-            <input
-              type="file"
-              accept="image/*"
-              ref={editFileInputRef}
-              onChange={(e) => {
-                setEditFile(e.target.files?.[0] ?? null);
-                // 새 파일 선택 시 삭제 플래그 해제
-                if (e.target.files?.[0]) setRemoveExistingImage(false);
-              }}
-              className="hidden"
-            />
-            {editFile ? (
-              <div className="p-2 bg-slate-50 border rounded-lg flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Paperclip className="h-4 w-4 text-blue-500" />
-                  <span className="text-sm text-slate-700 truncate max-w-[200px]">
-                    {editFile.name}
-                  </span>
-                </div>
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    setEditFile(null);
-                    if (editFileInputRef.current)
-                      editFileInputRef.current.value = "";
-                  }}
-                  className="h-7 w-7 p-0 hover:text-red-500"
-                >
-                  <X className="h-3 w-3" />
-                </Button>
-              </div>
-            ) : (
-              <Button
-                variant="outline"
-                onClick={() => editFileInputRef.current?.click()}
-                className="gap-2 text-slate-500 h-8 px-3 text-sm"
-              >
-                <Paperclip className="h-4 w-4" />
-                이미지 교체
-              </Button>
-            )}
-            {/* 기존 이미지가 있고 새 파일 미선택 시 삭제 버튼 표시 */}
-            {images.length > 0 &&
-              !editFile &&
-              (removeExistingImage ? (
-                <Button
-                  variant="outline"
-                  onClick={() => setRemoveExistingImage(false)}
-                  className="gap-2 text-blue-500 h-8 px-3 text-sm"
-                >
-                  이미지 복원
-                </Button>
-              ) : (
-                <Button
-                  variant="outline"
-                  onClick={() => setRemoveExistingImage(true)}
-                  className="gap-2 text-red-500 hover:text-red-600 h-8 px-3 text-sm"
-                >
-                  <X className="h-4 w-4" />
-                  이미지 삭제
-                </Button>
-              ))}
-          </div>
-          <p className="text-[10px] text-slate-400 mt-1">
-            내용 수정 후 상단의 체크 버튼을 눌러주세요.
-          </p>
         </div>
       ) : (
         <TiptapEditor
@@ -386,11 +314,40 @@ function CommentItemSVC({
 
       {images.length > 0 &&
         (isEditing && removeExistingImage ? (
-          <div className="px-2 mt-2 py-3 border border-dashed border-red-200 rounded-lg bg-red-50/50 text-center text-sm text-red-400">
-            저장 시 이미지가 삭제됩니다
+          <div className="mt-4">
+            <div className="rounded-xl border-2 border-dashed p-4 transition-colors bg-white border-slate-100 relative">
+              <div className="py-8 flex flex-col items-center justify-center space-y-2">
+                <div className="p-3 bg-slate-50 rounded-full">
+                  <Paperclip className="h-6 w-6 text-slate-300" />
+                </div>
+                <p className="text-sm text-slate-400">
+                  이미지만 첨부할 수 있습니다.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setRemoveExistingImage(false)}
+                className="absolute top-2 right-2 h-8 w-8 p-0 rounded-full hover:bg-red-50 hover:text-red-500"
+                title="복원"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
           </div>
-        ) : (
-          <div className="px-2 mt-2 space-y-3">
+        ) : isEditing && editFile ? null : (
+          <div className="mt-4 space-y-3 relative">
+            {isEditing && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setRemoveExistingImage(true)}
+                className="absolute top-2 right-2 z-10 h-8 w-8 p-0 rounded-full bg-white/95 hover:bg-red-50 hover:text-red-600 border shadow-sm"
+                title="삭제"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            )}
             {images.map((img) => (
               <div
                 key={img.id || img.filename}

--- a/src/app/(dashboard)/learners/communication/[communicationId]/_components/PostCommentSVC.tsx
+++ b/src/app/(dashboard)/learners/communication/[communicationId]/_components/PostCommentSVC.tsx
@@ -330,6 +330,7 @@ function CommentItemSVC({
                 onClick={() => setRemoveExistingImage(false)}
                 className="absolute top-2 right-2 h-8 w-8 p-0 rounded-full hover:bg-red-50 hover:text-red-500"
                 title="복원"
+                aria-label="첨부 이미지 복원"
               >
                 <X className="h-4 w-4" />
               </Button>
@@ -344,6 +345,7 @@ function CommentItemSVC({
                 onClick={() => setRemoveExistingImage(true)}
                 className="absolute top-2 right-2 z-10 h-8 w-8 p-0 rounded-full bg-white/95 hover:bg-red-50 hover:text-red-600 border shadow-sm"
                 title="삭제"
+                aria-label="첨부 이미지 삭제"
               >
                 <X className="h-4 w-4" />
               </Button>

--- a/src/app/(dashboard)/learners/communication/[communicationId]/_components/PostInfoSVC.tsx
+++ b/src/app/(dashboard)/learners/communication/[communicationId]/_components/PostInfoSVC.tsx
@@ -45,6 +45,10 @@ export default function PostInfoSVC({
 
   const canAction = isRegistered || isCompleted;
 
+  const isImportant = noticePostData?.isImportant;
+  const noticeLabel = isImportant ? "공지" : "자료";
+  const noticeColor = isImportant ? "blue" : "green";
+
   return (
     <Card className="border shadow-sm">
       <CardContent className="p-0">
@@ -67,7 +71,7 @@ export default function PostInfoSVC({
                 </Label>
                 <div className="mt-1">
                   {isNoticePost ? (
-                    <StatusLabel color="blue">공지</StatusLabel>
+                    <StatusLabel color={noticeColor}>{noticeLabel}</StatusLabel>
                   ) : (
                     <StatusLabel color="gray">문의</StatusLabel>
                   )}

--- a/src/app/(dashboard)/learners/communication/[communicationId]/page.tsx
+++ b/src/app/(dashboard)/learners/communication/[communicationId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState } from "react";
 import { useRouter, useParams, useSearchParams } from "next/navigation";
 import { JSONContent } from "@tiptap/react";
 
@@ -34,7 +34,6 @@ export default function CommunicationDetailPageSVC() {
   const typeParam = searchParams.get("type");
   const type: "notice" | "inquiry" =
     typeParam === "notice" ? "notice" : "inquiry";
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const isNoticePost = type === "notice";
 
@@ -219,7 +218,6 @@ export default function CommunicationDetailPageSVC() {
     const handleSuccess = () => {
       setAnswerContent({}); // 초기화 시 빈 객체
       setSelectedFile(null);
-      if (fileInputRef.current) fileInputRef.current.value = "";
     };
 
     const formData = new FormData();
@@ -303,12 +301,6 @@ export default function CommunicationDetailPageSVC() {
     );
   };
 
-  // 자료 변경
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) setSelectedFile(file);
-  };
-
   // 자료 다운로드
   const handleAttachmentClick = (file: CommonPostAttachment) => {
     const isVideo =
@@ -385,8 +377,6 @@ export default function CommunicationDetailPageSVC() {
             setAnswerContent={setAnswerContent}
             selectedFile={selectedFile}
             setSelectedFile={setSelectedFile}
-            fileInputRef={fileInputRef as React.RefObject<HTMLInputElement>}
-            handleFileChange={handleFileChange}
             handleSubmitAnswer={handleSubmitAnswer}
             onUpdateComment={handleUpdateComment}
             onDeleteComment={handleDeleteComment}

--- a/src/app/(dashboard)/learners/communication/[communicationId]/page.tsx
+++ b/src/app/(dashboard)/learners/communication/[communicationId]/page.tsx
@@ -321,15 +321,16 @@ export default function CommunicationDetailPageSVC() {
 
   return (
     <div className="container mx-auto space-y-8 p-6">
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <Title
-          title={isNoticePost ? "공지사항 상세" : "문의 상세"}
-          description={
-            isEditing
-              ? "게시글을 수정 중입니다."
-              : "게시글의 상세 내용을 확인하세요."
-          }
-        />
+      <Title
+        title={isNoticePost ? "공지사항 상세" : "문의 상세"}
+        description={
+          isEditing
+            ? "게시글을 수정 중입니다."
+            : "게시글의 상세 내용을 확인하세요."
+        }
+      />
+
+      <div className="flex items-center justify-end">
         <PostActionSVC
           isEditing={isEditing}
           isMine={currentData.isMine ?? false}

--- a/src/app/(dashboard)/learners/communication/_components/filter/TabSectionSVC.tsx
+++ b/src/app/(dashboard)/learners/communication/_components/filter/TabSectionSVC.tsx
@@ -33,7 +33,7 @@ export default function TabSectionSVC() {
 
   // 검색어 상태 및 디바운스
   const [searchTerm, setSearchTerm] = useState("");
-  const debouncedSearchTerm = useDebounce(searchTerm, 500);
+  const debouncedSearchTerm = useDebounce(searchTerm, 300);
 
   // 요청 쿼리
   const [query, setQuery] = useState<PostFilterQuery>({

--- a/src/app/(dashboard)/learners/communication/_components/filter/TabSectionSVC.tsx
+++ b/src/app/(dashboard)/learners/communication/_components/filter/TabSectionSVC.tsx
@@ -150,7 +150,7 @@ export default function TabSectionSVC() {
         />
       )}
 
-      <div className="min-h-[550px]">
+      <div>
         {isLoading ? (
           <div className="flex items-center justify-center h-[550px]">
             <p className="text-muted-foreground">로딩 중...</p>

--- a/src/app/(dashboard)/learners/communication/_components/table/NotificationTableColumnsSVC.tsx
+++ b/src/app/(dashboard)/learners/communication/_components/table/NotificationTableColumnsSVC.tsx
@@ -2,7 +2,6 @@ import StatusLabel from "@/components/common/label/StatusLabel";
 import { GetInstructorPostsResponse } from "@/types/communication/instructorPost";
 import { ColumnDefinition } from "@/components/common/table/DataTable";
 import { formatYMDFromISO } from "@/utils/date";
-import { NOTICE_TYPE_LABEL } from "@/constants/communication.default";
 
 type NoticeRow = GetInstructorPostsResponse["list"][number];
 

--- a/src/app/(dashboard)/learners/communication/_components/table/NotificationTableColumnsSVC.tsx
+++ b/src/app/(dashboard)/learners/communication/_components/table/NotificationTableColumnsSVC.tsx
@@ -49,23 +49,6 @@ export const NOTICE_TABLE_COLUMNS_SVC: ColumnDefinition<NoticeRow>[] = [
     },
   },
   {
-    key: "authorRole",
-    label: "열람 권한",
-    render: (row) => {
-      const info =
-        NOTICE_TYPE_LABEL[row.targetRole as keyof typeof NOTICE_TYPE_LABEL] ??
-        NOTICE_TYPE_LABEL.ALL;
-
-      return (
-        <div className="w-[50px] flex items-center">
-          <StatusLabel noBackground color={info.color}>
-            {info.label}
-          </StatusLabel>
-        </div>
-      );
-    },
-  },
-  {
     key: "instructor",
     label: "작성자",
     render: (row) => {

--- a/src/app/(dashboard)/learners/communication/page.tsx
+++ b/src/app/(dashboard)/learners/communication/page.tsx
@@ -17,7 +17,7 @@ export default function LearnersCommunicationPage() {
         </p>
       </section>
 
-      <div className="space-y-8">
+      <div className="space-y-2">
         <div className="flex flex-wrap items-center justify-end gap-3">
           <Button
             variant="default"
@@ -30,7 +30,7 @@ export default function LearnersCommunicationPage() {
 
         <Suspense
           fallback={
-            <div className="flex items-center justify-center h-[550px]">
+            <div className="flex items-center justify-center h-[300px]">
               <p className="text-muted-foreground">로딩 중...</p>
             </div>
           }

--- a/src/components/auth/form/LoginForm.tsx
+++ b/src/components/auth/form/LoginForm.tsx
@@ -24,14 +24,14 @@ type LoginFormProps = {
 
 const FOOTER_CONFIG = {
   STUDENT: {
-    question: "아직 계정이 없으신가요?",
-    action: "회원가입하기",
-    href: "/learners/register",
+    question: "",
+    action: "",
+    href: "",
   },
   PARENT: {
-    question: "아직 계정이 없으신가요?",
-    action: "회원가입하기",
-    href: "/learners/register",
+    question: "",
+    action: "",
+    href: "",
   },
   DEFAULT: {
     question: "관리자 권한이 필요하신가요?",

--- a/src/components/common/editor/TiptapEditor.tsx
+++ b/src/components/common/editor/TiptapEditor.tsx
@@ -27,7 +27,7 @@ type TiptapEditorProps = {
   placeholder?: string;
   className?: string;
   onFileUpload?: (file: File) => void;
-  attachment?: File;
+  attachment?: File | null;
   onRemoveAttachment?: () => void;
 };
 

--- a/src/constants/students.default.ts
+++ b/src/constants/students.default.ts
@@ -102,6 +102,7 @@ export const EDIT_PROFILE_FORM_DEFAULTS: EditProfileFormDataType = {
   schoolYear: "",
   studentPhone: "",
   parentPhone: "",
+  registeredAt: "",
   memo: "",
 };
 

--- a/src/hooks/useEnrollment.ts
+++ b/src/hooks/useEnrollment.ts
@@ -124,6 +124,8 @@ export const useEnrollmentDetail = (id: string) =>
 // 수강생 정보 수정
 export const useUpdateEnrollment = () => {
   const queryClient = useQueryClient();
+  const { showAlert } = useDialogAlert();
+
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: UpdateEnrollmentInfo }) =>
       api.updateEnrollmentAPI(id, data),
@@ -134,6 +136,10 @@ export const useUpdateEnrollment = () => {
       queryClient.invalidateQueries({
         queryKey: ["enrollments", "detail", id],
       });
+      showAlert({ description: "수강생 정보가 수정되었습니다." });
+    },
+    onError: () => {
+      showAlert({ description: "수강생 정보 수정에 실패했습니다." });
     },
   });
 };

--- a/src/types/students.type.ts
+++ b/src/types/students.type.ts
@@ -160,6 +160,7 @@ export type UpdateEnrollmentInfo = {
   school?: string;
   schoolYear?: string;
   status?: StudentStatus;
+  registeredAt?: string;
   memo?: string | null;
 };
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,3 +1,5 @@
+import { parseISO, startOfDay } from "date-fns";
+
 // 한국 시간 기준으로 날짜 객체 생성
 const getKoreaDate = (date?: string | Date) => {
   return date ? new Date(date) : new Date();
@@ -26,8 +28,17 @@ export const formatDateYMD = (isoDate?: string | null) => {
   return date.toLocaleDateString("sv-SE");
 };
 
-// YYYY-MM-DD를 ISO 8601 datetime 문자열로 변환\
+// YYYY-MM-DD를 ISO 8601 datetime 문자열로 변환
 export const toISOFromYMD = (yyyyMmDd: string): string => {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(yyyyMmDd)) return yyyyMmDd;
-  return `${yyyyMmDd}T00:00:00.000Z`;
+
+  // 1. 문자열을 Date 객체로 파싱 (기본적으로 로컬/한국 시간 기준)
+  const date = parseISO(yyyyMmDd);
+
+  // 2. 해당 날짜의 시작 시각(00:00:00) 설정
+  const startOfDate = startOfDay(date);
+
+  // 3. ISO 8601 형식으로 변환 (toISOString은 항상 UTC 'Z' 값을 반환함)
+  // 예: 2026-03-14 (KST 00:00) -> 2026-03-13T15:00:00.000Z (UTC)
+  return startOfDate.toISOString();
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -25,3 +25,9 @@ export const formatDateYMD = (isoDate?: string | null) => {
   if (Number.isNaN(date.getTime())) return undefined;
   return date.toLocaleDateString("sv-SE");
 };
+
+// YYYY-MM-DD를 ISO 8601 datetime 문자열로 변환\
+export const toISOFromYMD = (yyyyMmDd: string): string => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(yyyyMmDd)) return yyyyMmDd;
+  return `${yyyyMmDd}T00:00:00.000Z`;
+};

--- a/src/validation/students.validation.ts
+++ b/src/validation/students.validation.ts
@@ -37,6 +37,7 @@ export const editProfileSchema = studentBaseSchema.extend({
     .min(1, "이메일을 입력해주세요")
     .optional()
     .or(z.literal("")), // 빈 문자열 허용(미등록 학생일 경우)
+  registeredAt: z.string().optional(),
   memo: z.string().optional(),
 });
 


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #이슈번호

## ✨ 작업 단계 및 변경 사항

- **작업 단계:**  Phase 3: QA 2차
- **변경 사항:**
  - 학생/학부모 회원가입 루트 숨김처리
  - 게시글 정보의 공지사항 분류 표기 오류 수정
  - 강사/조교 수신 대상 선택 시 학생명 표기(학생/학부모는 기존 상태 유지 - 특정 학생)
  - 강사/조교 소통 테이블 열람 권한 표기 스타일 변경(사용자 이해 쉽도록)
  - 학생/학부모 소통 테이블 열람 권한 표기 제거(불필요)
  - 학생 정보 수정 모달에 등록일 수정 기능 추가 + CheckModal 정상 적용
  - 댓글 이미지 첨부 기능 보완
    - 수정/복원 버튼 통일
    - 댓글 전용 에디터 첨부파일 버튼 표기
    - 이미지만 첨부 가능 텍스트 추가
    - 파일 수정/삭제 기능 정상화

- **참고 사항:**
  - 변경 사항 이미지 확인: https://www.notion.so/1-5-QA-3226f28c193e804999c4ec633b149902?source=copy_link

## 🧪 테스트 방법

리뷰어가 확인해야 할 핵심 포인트를 적어주세요.

- [ ] 댓글 첨부파일 기능 체크
- [ ] 변경사항 체크

## 📸 스크린샷 (선택)

- UI 변경이 있거나 Phase 2 작업인 경우 반드시 첨부해주세요.

## ✅ 체크리스트

- [ ] `Phase`에 맞는 이슈 체크리스트를 모두 완료했는가?
- [ ] lint / type-check 통과 및 불필요한 console.log 제거
- [ ] **머지 후 이 이슈가 [QA] 컬럼으로 이동함을 인지하고 있는가?**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Student profiles now include a registration date (editable) and date handling for saves.
  * Post notice labels are dynamic (공지 vs 자료) based on importance.

* **Improvements**
  * Redesigned image attachment flow in comments: image-only notice, inline attachment display, delete/restore actions, and adjusted submit styling.
  * Faster search responsiveness (debounce 300ms).
  * Simplified login footer for Student/Parent roles.
  * Leaner learner page spacing and smaller loading placeholder.
  * Enrollment updates now show success/error alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->