### PR TITLE
fix: apply second QA fixes

### DIFF
--- a/src/app/(dashboard)/educators/assistants/_hooks/manage/useResourceLibrarySelection.ts
+++ b/src/app/(dashboard)/educators/assistants/_hooks/manage/useResourceLibrarySelection.ts
@@ -14,8 +14,11 @@ const toResourceLibraryItem = (material: Materials): ResourceLibraryItem => ({
   title: material.title,
   category: getResourceLibraryCategoryByMaterialsType(material.type),
   updatedAt: material.date,
-  sizeLabel:
-    material.file?.name ?? (material.link?.trim() ? "링크 자료" : "파일 없음"),
+  sizeLabel: material.file?.name
+    ? material.title
+    : material.link?.trim()
+      ? "링크 자료"
+      : "파일 없음",
 });
 
 const getErrorMessage = (error: unknown) => {

--- a/src/app/(dashboard)/educators/profile/_components/AcademyAndLectures.tsx
+++ b/src/app/(dashboard)/educators/profile/_components/AcademyAndLectures.tsx
@@ -39,9 +39,11 @@ export function AcademyAndLectures({
                 >
                   <div className="space-y-6 px-6 pb-4 pt-6">
                     <div className="flex flex-wrap gap-2">
-                      <span className="rounded-lg bg-[#e1e7fe] px-3 py-2 text-[14px] font-semibold leading-5 tracking-[-0.02em] text-[#2554f5]">
-                        {academyName}
-                      </span>
+                      {academyName !== "-" && (
+                        <span className="rounded-lg bg-[#e1e7fe] px-3 py-2 text-[14px] font-semibold leading-5 tracking-[-0.02em] text-[#2554f5]">
+                          {academyName}
+                        </span>
+                      )}
                       <span className="rounded-lg bg-[#e9ebf0] px-3 py-2 text-[14px] font-semibold leading-5 tracking-[-0.02em] text-[#5e6275]">
                         {lecture.target}
                       </span>

--- a/src/app/(dashboard)/educators/profile/_components/modal/SettingsSecurityModal.tsx
+++ b/src/app/(dashboard)/educators/profile/_components/modal/SettingsSecurityModal.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ArrowLeft, Lock, UserX } from "lucide-react";
+import { ArrowLeft, Lock, Users, UserX } from "lucide-react";
 
 import {
   Dialog,
@@ -24,15 +24,26 @@ import {
   type PasswordChangeFormData,
   type VerificationCodeFormData,
 } from "@/validation/profile.validation";
+import {
+  linkChildSchema,
+  type LinkChildFormData,
+} from "@/validation/learners-profile.validation";
 import { EyeClosedIcon, EyeOpenIcon } from "@/components/icons/AuthIcons";
+import { formatPhoneNumber } from "@/utils/phone";
 
-type ViewMode = "menu" | "password";
+type ViewMode = "menu" | "password" | "linkChild";
 
 type SettingsSecurityModalProps = {
   email: string;
+  onLinkChild?: (data: LinkChildFormData) => Promise<unknown>;
+  isLinkingChild?: boolean;
 };
 
-export function SettingsSecurityModal({ email }: SettingsSecurityModalProps) {
+export function SettingsSecurityModal({
+  email,
+  onLinkChild,
+  isLinkingChild,
+}: SettingsSecurityModalProps) {
   const { isOpen, closeModal, openModal } = useModal();
   const { user } = useAuthContext();
   const [viewMode, setViewMode] = useState<ViewMode>("menu");
@@ -70,9 +81,26 @@ export function SettingsSecurityModal({ email }: SettingsSecurityModalProps) {
     mode: "onChange",
   });
 
+  const {
+    register: registerChild,
+    handleSubmit: handleChildSubmit,
+    formState: { errors: childErrors, isValid: isChildValid },
+    setValue: setChildValue,
+    reset: resetChild,
+    control: childControl,
+  } = useForm<LinkChildFormData>({
+    resolver: zodResolver(linkChildSchema),
+    mode: "onChange",
+  });
+
   const currentPasswordValue = useWatch({ control, name: "currentPassword" });
   const newPasswordValue = useWatch({ control, name: "newPassword" });
   const confirmPasswordValue = useWatch({ control, name: "confirmPassword" });
+  const childNameValue = useWatch({ control: childControl, name: "name" });
+  const childPhoneValue = useWatch({
+    control: childControl,
+    name: "phoneNumber",
+  });
 
   const handleClose = () => {
     setViewMode("menu");
@@ -82,6 +110,7 @@ export function SettingsSecurityModal({ email }: SettingsSecurityModalProps) {
     setFeedbackTone("success");
     resetCode();
     reset();
+    resetChild();
     setShowNewPwd(false);
     setShowConfirmPwd(false);
     closeModal();
@@ -99,6 +128,7 @@ export function SettingsSecurityModal({ email }: SettingsSecurityModalProps) {
     setFeedbackTone("success");
     resetCode();
     reset();
+    resetChild();
     setShowNewPwd(false);
     setShowConfirmPwd(false);
   };
@@ -170,6 +200,24 @@ export function SettingsSecurityModal({ email }: SettingsSecurityModalProps) {
     }
   };
 
+  const onLinkChildSubmit = async (data: LinkChildFormData) => {
+    setFeedbackMessage(null);
+
+    try {
+      await onLinkChild?.(data);
+      setFeedbackTone("success");
+      setFeedbackMessage("자녀가 연동되었습니다.");
+      setTimeout(() => handleClose(), 1000);
+    } catch (error) {
+      setFeedbackTone("error");
+      setFeedbackMessage(
+        error instanceof Error
+          ? error.message
+          : "자녀 연동 중 오류가 발생했습니다."
+      );
+    }
+  };
+
   const handleWithdrawal = () => {
     openModal(
       <CheckModal
@@ -185,6 +233,13 @@ export function SettingsSecurityModal({ email }: SettingsSecurityModalProps) {
     );
   };
 
+  const dialogTitle =
+    viewMode === "menu"
+      ? "설정 및 보안"
+      : viewMode === "password"
+        ? "비밀번호 변경"
+        : "자녀 연동하기";
+
   return (
     <Dialog
       open={isOpen}
@@ -197,11 +252,11 @@ export function SettingsSecurityModal({ email }: SettingsSecurityModalProps) {
       <DialogContent className="w-[calc(100vw-32px)] max-h-[88vh] max-w-[620px] gap-0 overflow-y-auto rounded-[24px] border-0 bg-white p-0 shadow-[0_0_14px_rgba(138,138,138,0.16)]">
         <DialogHeader className="gap-2 border-b border-[#e9ebf0] px-6 pb-5 pt-6 sm:px-8">
           <DialogTitle className="text-[24px] font-bold leading-8 tracking-[-0.02em] text-[#040405]">
-            {viewMode === "menu" ? "설정 및 보안" : "비밀번호 변경"}
+            {dialogTitle}
           </DialogTitle>
         </DialogHeader>
 
-        {viewMode === "menu" ? (
+        {viewMode === "menu" && (
           <div className="space-y-4 px-6 pb-6 pt-6 sm:px-8 sm:pb-8">
             <Button
               variant="outline"
@@ -211,6 +266,16 @@ export function SettingsSecurityModal({ email }: SettingsSecurityModalProps) {
               <Lock className="mr-3 h-5 w-5" />
               비밀번호 변경하기
             </Button>
+            {user?.userType === "PARENT" && onLinkChild && (
+              <Button
+                variant="outline"
+                className="h-14 w-full justify-start rounded-[12px] border border-[#d6d9e0] bg-white px-5 text-[16px] font-semibold tracking-[-0.02em] text-[#4a4d5c] shadow-[0_0_14px_rgba(138,138,138,0.08)] hover:bg-[#fcfcfd]"
+                onClick={() => setViewMode("linkChild")}
+              >
+                <Users className="mr-3 h-5 w-5" />
+                자녀 연동하기
+              </Button>
+            )}
             <Button
               variant="outline"
               className="h-14 w-full justify-start rounded-[12px] border border-[#fee2e2] bg-[#fff7f7] px-5 text-[16px] font-semibold tracking-[-0.02em] text-[#dc2626] shadow-[0_0_14px_rgba(138,138,138,0.08)] hover:bg-[#ffefef] hover:text-[#b91c1c]"
@@ -220,7 +285,9 @@ export function SettingsSecurityModal({ email }: SettingsSecurityModalProps) {
               서비스 탈퇴하기
             </Button>
           </div>
-        ) : (
+        )}
+
+        {viewMode === "password" && (
           <form
             onSubmit={handleSubmit(onSubmit)}
             className="space-y-5 px-6 pb-6 pt-6 sm:px-8 sm:pb-8"
@@ -377,6 +444,77 @@ export function SettingsSecurityModal({ email }: SettingsSecurityModalProps) {
                 disabled={!isVerified || !isValid}
               >
                 변경하기
+              </Button>
+            </div>
+          </form>
+        )}
+
+        {viewMode === "linkChild" && (
+          <form
+            onSubmit={handleChildSubmit(onLinkChildSubmit)}
+            className="space-y-5 px-6 pb-6 pt-6 sm:px-8 sm:pb-8"
+          >
+            {feedbackMessage ? (
+              <p
+                className={`rounded-[12px] border px-4 py-3 text-[14px] font-medium leading-5 tracking-[-0.02em] ${
+                  feedbackTone === "success"
+                    ? "border-[#ced9fd] bg-[#f4f6fe] text-[#3863f6]"
+                    : "border-[#fee2e2] bg-[#fff7f7] text-[#dc2626]"
+                }`}
+              >
+                {feedbackMessage}
+              </p>
+            ) : null}
+
+            <InputForm
+              label="자녀 이름"
+              type="text"
+              placeholder="자녀 이름을 입력해주세요"
+              {...registerChild("name")}
+              error={childErrors.name?.message}
+              showReset={!!childNameValue}
+              onReset={() =>
+                setChildValue("name", "", { shouldValidate: true })
+              }
+              className="h-14 rounded-[12px] border-[#d6d9e0] bg-white px-4 text-[16px] font-medium tracking-[-0.02em] text-[#2b2e3a]"
+            />
+
+            <InputForm
+              label="자녀 전화번호"
+              type="tel"
+              placeholder="010-0000-0000"
+              {...registerChild("phoneNumber", {
+                onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+                  const formatted = formatPhoneNumber(e.target.value);
+                  setChildValue("phoneNumber", formatted, {
+                    shouldValidate: true,
+                  });
+                },
+              })}
+              error={childErrors.phoneNumber?.message}
+              showReset={!!childPhoneValue}
+              onReset={() =>
+                setChildValue("phoneNumber", "", { shouldValidate: true })
+              }
+              className="h-14 rounded-[12px] border-[#d6d9e0] bg-white px-4 text-[16px] font-medium tracking-[-0.02em] text-[#2b2e3a]"
+            />
+
+            <div className="mt-6 flex gap-2 border-t border-[#e9ebf0] pt-5">
+              <Button
+                type="button"
+                variant="outline"
+                className="h-12 flex-1 rounded-[12px] border border-[#ced9fd] bg-[#f4f6fe] text-[14px] font-semibold tracking-[-0.02em] text-[#3863f6] shadow-[0_0_14px_rgba(138,138,138,0.08)] hover:bg-[#e8edfe]"
+                onClick={handleBack}
+              >
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                뒤로 가기
+              </Button>
+              <Button
+                type="submit"
+                className="h-12 flex-1 rounded-[12px] bg-[#3863f6] text-[14px] font-semibold tracking-[-0.02em] text-white shadow-[0_0_14px_rgba(138,138,138,0.08)] hover:bg-[#2f57e8]"
+                disabled={!isChildValid || isLinkingChild}
+              >
+                {isLinkingChild ? "연동 중..." : "연동하기"}
               </Button>
             </div>
           </form>

--- a/src/app/(dashboard)/educators/profile/_components/modal/SettingsSecurityModal.tsx
+++ b/src/app/(dashboard)/educators/profile/_components/modal/SettingsSecurityModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ArrowLeft, Lock, Users, UserX } from "lucide-react";
@@ -36,13 +36,11 @@ type ViewMode = "menu" | "password" | "linkChild";
 type SettingsSecurityModalProps = {
   email: string;
   onLinkChild?: (data: LinkChildFormData) => Promise<unknown>;
-  isLinkingChild?: boolean;
 };
 
 export function SettingsSecurityModal({
   email,
   onLinkChild,
-  isLinkingChild,
 }: SettingsSecurityModalProps) {
   const { isOpen, closeModal, openModal } = useModal();
   const { user } = useAuthContext();
@@ -56,6 +54,8 @@ export function SettingsSecurityModal({
   const [feedbackTone, setFeedbackTone] = useState<"success" | "error">(
     "success"
   );
+  const [isLinkingChild, setIsLinkingChild] = useState(false);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const {
     register: registerCode,
@@ -102,12 +102,23 @@ export function SettingsSecurityModal({
     name: "phoneNumber",
   });
 
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    };
+  }, []);
+
   const handleClose = () => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
     setViewMode("menu");
     setIsCodeSent(false);
     setIsVerified(false);
     setFeedbackMessage(null);
     setFeedbackTone("success");
+    setIsLinkingChild(false);
     resetCode();
     reset();
     resetChild();
@@ -201,13 +212,16 @@ export function SettingsSecurityModal({
   };
 
   const onLinkChildSubmit = async (data: LinkChildFormData) => {
+    if (!onLinkChild) return;
+
     setFeedbackMessage(null);
+    setIsLinkingChild(true);
 
     try {
-      await onLinkChild?.(data);
+      await onLinkChild(data);
       setFeedbackTone("success");
       setFeedbackMessage("자녀가 연동되었습니다.");
-      setTimeout(() => handleClose(), 1000);
+      closeTimerRef.current = setTimeout(() => handleClose(), 1000);
     } catch (error) {
       setFeedbackTone("error");
       setFeedbackMessage(
@@ -215,6 +229,8 @@ export function SettingsSecurityModal({
           ? error.message
           : "자녀 연동 중 오류가 발생했습니다."
       );
+    } finally {
+      setIsLinkingChild(false);
     }
   };
 

--- a/src/app/(dashboard)/educators/profile/page.tsx
+++ b/src/app/(dashboard)/educators/profile/page.tsx
@@ -99,7 +99,11 @@ export default function ProfilePage() {
 
       <AcademyAndLectures
         academyName={profile.academyName}
-        teacherName={profile.name}
+        teacherName={
+          profile.role === "ASSISTANT" && profile.instructorName
+            ? profile.instructorName
+            : profile.name
+        }
         lectures={lectures}
       />
     </div>

--- a/src/app/(dashboard)/learners/lectures/[lectureEnrollmentId]/exams/[examId]/page.tsx
+++ b/src/app/(dashboard)/learners/lectures/[lectureEnrollmentId]/exams/[examId]/page.tsx
@@ -114,14 +114,14 @@ export default function LearnersExamDetailPage() {
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <MetricCard
           label="내 점수"
-          value={detail.score}
+          value={Number(detail.score).toFixed(1)}
           unit="점"
           icon={Trophy}
           trend="score"
         />
         <MetricCard
           label="학급 평균"
-          value={detail.classAverage}
+          value={Number(detail.classAverage).toFixed(1)}
           unit="점"
           icon={Users}
         />

--- a/src/app/(dashboard)/learners/lectures/_components/ExamListTable.tsx
+++ b/src/app/(dashboard)/learners/lectures/_components/ExamListTable.tsx
@@ -90,10 +90,10 @@ export default function ExamListTable({
                     </span>
                   </TableCell>
                   <TableCell className="px-6 py-5 text-center text-base font-bold text-brand-700">
-                    {grade.score}점
+                    {Number(grade.score).toFixed(1)}점
                   </TableCell>
                   <TableCell className="px-6 py-5 text-center text-base text-neutral-500">
-                    {exam.average}점
+                    {Number(exam.average).toFixed(1)}점
                   </TableCell>
                   <TableCell className="px-6 py-5 text-center text-base text-neutral-500">
                     <span className="font-semibold text-neutral-700">

--- a/src/app/(dashboard)/learners/lectures/_components/ScoreChart.tsx
+++ b/src/app/(dashboard)/learners/lectures/_components/ScoreChart.tsx
@@ -137,7 +137,9 @@ const CustomTooltip = ({
           <div className="grid grid-cols-2 gap-x-4">
             <div>
               <p className="mb-2 text-[#8b90a3]">점수</p>
-              <p className="font-semibold text-[#3863f6]">{data.score}점</p>
+              <p className="font-semibold text-[#3863f6]">
+                {Number(data.score).toFixed(1)}점
+              </p>
             </div>
             <div>
               <p className="mb-2 text-[#8b90a3]">석차</p>
@@ -149,7 +151,7 @@ const CustomTooltip = ({
         </div>
 
         <div className="mt-6 border-t border-dashed border-[#e9ebf0] pt-3 text-[11px] text-[#8b90a3]">
-          반 평균 | {data.classAverage}점
+          반 평균 | {Number(data.classAverage).toFixed(1)}점
         </div>
       </div>
     );

--- a/src/app/(dashboard)/learners/profile/page.tsx
+++ b/src/app/(dashboard)/learners/profile/page.tsx
@@ -6,7 +6,10 @@ import { useSetBreadcrumb } from "@/hooks/useBreadcrumb";
 import { useDialogAlert } from "@/hooks/useDialogAlert";
 import { useModal } from "@/providers/ModalProvider";
 import { useMyLearnerProfile } from "@/hooks/profile/useMyLearnerProfile";
-import type { LearnersProfileUpdateFormData } from "@/validation/learners-profile.validation";
+import type {
+  LearnersProfileUpdateFormData,
+  LinkChildFormData,
+} from "@/validation/learners-profile.validation";
 import { PhoneChangeModal } from "@/app/(dashboard)/educators/profile/_components/modal/PhoneChangeModal";
 import { SettingsSecurityModal } from "@/app/(dashboard)/educators/profile/_components/modal/SettingsSecurityModal";
 
@@ -19,8 +22,15 @@ export default function LearnersProfilePage() {
   useSetBreadcrumb([{ label: "프로필" }]);
 
   const { openModal, closeModal } = useModal();
-  const { profile, isPending, isError, updateProfile, isUpdating } =
-    useMyLearnerProfile();
+  const {
+    profile,
+    isPending,
+    isError,
+    updateProfile,
+    isUpdating,
+    linkChild,
+    isLinkingChild,
+  } = useMyLearnerProfile();
   const { showAlert } = useDialogAlert();
 
   const profileRef = useRef(profile);
@@ -28,6 +38,7 @@ export default function LearnersProfilePage() {
   const updateProfileRef = useRef(updateProfile);
   const closeModalRef = useRef(closeModal);
   const showAlertRef = useRef(showAlert);
+  const linkChildRef = useRef(linkChild);
 
   useEffect(() => {
     profileRef.current = profile;
@@ -48,6 +59,10 @@ export default function LearnersProfilePage() {
   useEffect(() => {
     showAlertRef.current = showAlert;
   }, [showAlert]);
+
+  useEffect(() => {
+    linkChildRef.current = linkChild;
+  }, [linkChild]);
 
   const handleProfileUpdate = useCallback(
     async (data: LearnersProfileUpdateFormData) => {
@@ -70,6 +85,10 @@ export default function LearnersProfilePage() {
     []
   );
 
+  const handleLinkChild = useCallback(async (data: LinkChildFormData) => {
+    await linkChildRef.current(data);
+  }, []);
+
   const handleEditClick = () => {
     if (!profile) return;
 
@@ -84,7 +103,15 @@ export default function LearnersProfilePage() {
   const handleSettingsClick = () => {
     if (!profile) return;
 
-    openModal(<SettingsSecurityModal email={profile.email} />);
+    openModal(
+      <SettingsSecurityModal
+        email={profile.email}
+        onLinkChild={
+          profile.userType === "PARENT" ? handleLinkChild : undefined
+        }
+        isLinkingChild={isLinkingChild}
+      />
+    );
   };
 
   const handlePhoneChangeClick = () => {

--- a/src/app/(dashboard)/learners/profile/page.tsx
+++ b/src/app/(dashboard)/learners/profile/page.tsx
@@ -22,15 +22,8 @@ export default function LearnersProfilePage() {
   useSetBreadcrumb([{ label: "프로필" }]);
 
   const { openModal, closeModal } = useModal();
-  const {
-    profile,
-    isPending,
-    isError,
-    updateProfile,
-    isUpdating,
-    linkChild,
-    isLinkingChild,
-  } = useMyLearnerProfile();
+  const { profile, isPending, isError, updateProfile, isUpdating, linkChild } =
+    useMyLearnerProfile();
   const { showAlert } = useDialogAlert();
 
   const profileRef = useRef(profile);
@@ -109,7 +102,6 @@ export default function LearnersProfilePage() {
         onLinkChild={
           profile.userType === "PARENT" ? handleLinkChild : undefined
         }
-        isLinkingChild={isLinkingChild}
       />
     );
   };

--- a/src/data/profile.mock.ts
+++ b/src/data/profile.mock.ts
@@ -12,6 +12,7 @@ export const mockProfile: Profile = {
   bio: "10년 경력의 영어 전문 강사입니다.",
   createdAt: "2026-02-01T09:00:00Z",
   role: "INSTRUCTOR",
+  instructorName: null,
 };
 
 export const mockLectures: Lecture[] = [

--- a/src/hooks/profile/useMyLearnerProfile.ts
+++ b/src/hooks/profile/useMyLearnerProfile.ts
@@ -8,8 +8,10 @@ import {
 import {
   fetchMyLearnerProfileAPI,
   updateMyLearnerProfileAPI,
+  linkChildAPI,
 } from "@/services/learnersProfile.service";
 import type { LearnersProfileUpdateFormData } from "@/validation/learners-profile.validation";
+import type { LinkChildFormData } from "@/validation/learners-profile.validation";
 
 export const useMyLearnerProfile = () => {
   const queryClient = useQueryClient();
@@ -45,6 +47,22 @@ export const useMyLearnerProfile = () => {
     },
   });
 
+  const linkChildMutation = useMutation({
+    mutationFn: (payload: LinkChildFormData) =>
+      linkChildAPI({
+        name: payload.name.trim(),
+        phoneNumber: payload.phoneNumber,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: profileKeys.learnerMe() });
+    },
+    onError: (error) => {
+      const normalizedError =
+        error instanceof Error ? error : new Error(String(error));
+      console.error("자녀 연동 실패:", normalizedError.message);
+    },
+  });
+
   return {
     profile: profileQuery.data ?? null,
     isPending: profileQuery.isPending,
@@ -53,5 +71,7 @@ export const useMyLearnerProfile = () => {
     refetch: profileQuery.refetch,
     updateProfile: updateMutation.mutateAsync,
     isUpdating: updateMutation.isPending,
+    linkChild: linkChildMutation.mutateAsync,
+    isLinkingChild: linkChildMutation.isPending,
   };
 };

--- a/src/mappers/profile.mapper.ts
+++ b/src/mappers/profile.mapper.ts
@@ -42,6 +42,7 @@ export const mapMyProfileApiToView = (payload: MyProfileApiResponse) => {
     bio: payload.bio ?? "",
     createdAt: payload.createdAt ?? "",
     role: mapProfileRole(payload.userType),
+    instructorName: payload.instructor?.name ?? null,
   };
 
   const rawLectures = payload.lectures ?? payload.instructorLectures ?? [];

--- a/src/mappers/profile.mapper.ts
+++ b/src/mappers/profile.mapper.ts
@@ -42,7 +42,7 @@ export const mapMyProfileApiToView = (payload: MyProfileApiResponse) => {
     bio: payload.bio ?? "",
     createdAt: payload.createdAt ?? "",
     role: mapProfileRole(payload.userType),
-    instructorName: payload.instructor?.name ?? null,
+    instructorName: toOptionalString(payload.instructor?.name) ?? null,
   };
 
   const rawLectures = payload.lectures ?? payload.instructorLectures ?? [];

--- a/src/services/learnersProfile.service.ts
+++ b/src/services/learnersProfile.service.ts
@@ -22,3 +22,25 @@ export const updateMyLearnerProfileAPI = async (
 
   return data.data;
 };
+
+export type LinkChildPayload = {
+  name: string;
+  phoneNumber: string;
+};
+
+type LinkChildApiResponse = {
+  id: string;
+  name: string;
+  phoneNumber: string;
+};
+
+export const linkChildAPI = async (
+  payload: LinkChildPayload
+): Promise<LinkChildApiResponse> => {
+  const { data } = await axiosClientSVC.post<ApiResponse<LinkChildApiResponse>>(
+    "/children",
+    payload
+  );
+
+  return data.data;
+};

--- a/src/types/profile.api.ts
+++ b/src/types/profile.api.ts
@@ -20,6 +20,7 @@ export type MyProfileApiResponse = {
   phoneVerified?: boolean | null;
   lectures?: ProfileApiLecture[];
   instructorLectures?: ProfileApiLecture[];
+  instructor?: { id: string; name: string } | null;
 };
 
 export type UpdateMyProfilePayload = {

--- a/src/types/profile.type.ts
+++ b/src/types/profile.type.ts
@@ -10,6 +10,7 @@ export type Profile = {
   bio: string;
   createdAt: string;
   role: "INSTRUCTOR" | "ASSISTANT";
+  instructorName: string | null;
 };
 
 export type Lecture = {

--- a/src/validation/learners-profile.validation.ts
+++ b/src/validation/learners-profile.validation.ts
@@ -28,3 +28,21 @@ export const learnersProfileUpdateSchema = z.object({
 export type LearnersProfileUpdateFormData = z.infer<
   typeof learnersProfileUpdateSchema
 >;
+
+export const linkChildSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "자녀 이름을 입력해주세요")
+    .min(2, "이름은 최소 2자 이상이어야 합니다"),
+  phoneNumber: z
+    .string()
+    .trim()
+    .min(1, "전화번호를 입력해주세요")
+    .refine(
+      (value) => KR_PHONE_REGEX.test(value.replace(/-/g, "")),
+      "전화번호 형식이 올바르지 않습니다 (예: 010-1234-5678)"
+    ),
+});
+
+export type LinkChildFormData = z.infer<typeof linkChildSchema>;


### PR DESCRIPTION
## Summary
- 조교 프로필 담당강사명이 로그인 사용자명 대신 실제 강사명(instructor.name) 표시되도록 수정
- 조교 프로필 소속학원 뱃지 데이터 없을 시(`-`) 숨김 처리
- 자료실 모달에서 깨진 파일명(UTF-8 인코딩 이슈) 대신 자료 title 표시
- 학생 시험 점수 소수 첫째 자리까지 표기 (`toFixed(1)`)
- 학부모 자녀 연동 기능 구현 (설정 및 보안 모달 내 자녀 연동하기 뷰 추가)

## Changed Files (15)
- `profile.api.ts`, `profile.type.ts`, `profile.mapper.ts` — instructor 필드 추가/매핑
- `educators/profile/page.tsx` — 조교일 때 instructorName 사용
- `AcademyAndLectures.tsx` — 학원명 없을 시 뱃지 숨김
- `useResourceLibrarySelection.ts` — 파일명 대신 title 표시
- `ExamListTable.tsx`, `ScoreChart.tsx`, `exams/[examId]/page.tsx` — 소수점 1자리 표기
- `learners-profile.validation.ts` — linkChildSchema 추가
- `learnersProfile.service.ts` — linkChildAPI 추가
- `useMyLearnerProfile.ts` — linkChild mutation 추가
- `SettingsSecurityModal.tsx` — 자녀 연동 뷰 추가
- `learners/profile/page.tsx` — onLinkChild 콜백 연결
- `profile.mock.ts` — instructorName 필드 추가

## Test plan
- [ ] 조교 로그인 → 프로필 → 담당강사명이 실제 강사명으로 표시 확인
- [ ] 조교 프로필에서 소속학원 뱃지가 숨겨지는지 확인
- [ ] 자료실 모달에서 자료 제목이 정상 표시되는지 확인
- [ ] 학생 시험 점수가 소수 첫째 자리까지 표시되는지 확인
- [ ] 학부모 로그인 → 프로필 → 설정 및 보안 → 자녀 연동하기 버튼 노출 확인
- [ ] 자녀 이름 + 전화번호 입력 → 연동 성공 확인
- [ ] 학생/강사/조교 로그인 시 자녀 연동 버튼 미노출 확인

## Note
> 학생/학부모 대시보드 "최근 공지사항" 미노출 이슈는 BE 쿼리 버그 (SELECTED 스코프만 조회)로 확인. BE 수정 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Child linking flow added to security settings for parents, with validation and real-time phone formatting.

* **Bug Fixes**
  * Academy badge now only appears for valid academy names.
  * Score and class-average values consistently display with one decimal place.
  * Teacher name display corrected for assistant instructors.
  * Resource items now show the material title as the size/label fallback instead of the file name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->