### PR TITLE
Hotfix/ghost student filter

### DIFF
--- a/src/app/(dashboard)/educators/students/[studentId]/page.tsx
+++ b/src/app/(dashboard)/educators/students/[studentId]/page.tsx
@@ -281,43 +281,51 @@ export default function StudentDetailPage() {
           </span>
         </div>
 
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {enrolledLectures
-            .slice(0, visibleLectures)
-            .map((lecture: GetEnrollmentDetail["lectures"][0]) => {
-              const scheduleMeta = getScheduleMeta(lecture.lectureTimes);
+        {enrolledLectures.length === 0 ? (
+          <p className="rounded-[20px] border border-dashed border-neutral-200 bg-neutral-50/50 py-12 text-center text-sm text-neutral-500">
+            배정된 수업이 없습니다.
+          </p>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {enrolledLectures
+                .slice(0, visibleLectures)
+                .map((lecture: GetEnrollmentDetail["lectures"][0]) => {
+                  const scheduleMeta = getScheduleMeta(lecture.lectureTimes);
 
-              return (
-                <CommonLectureCard
-                  key={lecture.id}
-                  subject={lecture.subject}
-                  schoolYear={lecture.schoolYear}
-                  title={lecture.title}
-                  scheduleDays={scheduleMeta.scheduleDays}
-                  scheduleTime={scheduleMeta.scheduleTime}
-                  hasSchedule={scheduleMeta.hasSchedule}
-                  instructorName={enrollmentData.instructorName}
-                  onClick={() =>
-                    router.push(
-                      `/educators/students/${studentId}/lectures/${lecture.lectureEnrollmentId}`
-                    )
-                  }
-                  className="h-full"
-                />
-              );
-            })}
-        </div>
+                  return (
+                    <CommonLectureCard
+                      key={lecture.id}
+                      subject={lecture.subject}
+                      schoolYear={lecture.schoolYear}
+                      title={lecture.title}
+                      scheduleDays={scheduleMeta.scheduleDays}
+                      scheduleTime={scheduleMeta.scheduleTime}
+                      hasSchedule={scheduleMeta.hasSchedule}
+                      instructorName={enrollmentData.instructorName}
+                      onClick={() =>
+                        router.push(
+                          `/educators/students/${studentId}/lectures/${lecture.lectureEnrollmentId}`
+                        )
+                      }
+                      className="h-full"
+                    />
+                  );
+                })}
+            </div>
 
-        {visibleLectures < enrolledLectures.length && (
-          <div className="flex justify-center pt-4">
-            <Button
-              variant="outline"
-              className="h-12 rounded-[12px] border border-neutral-200 bg-white px-6 text-[16px] font-semibold text-neutral-400 hover:bg-neutral-50"
-              onClick={handleLoadMore}
-            >
-              더보기 ({enrolledLectures.length - visibleLectures})
-            </Button>
-          </div>
+            {visibleLectures < enrolledLectures.length && (
+              <div className="flex justify-center pt-4">
+                <Button
+                  variant="outline"
+                  className="h-12 rounded-[12px] border border-neutral-200 bg-white px-6 text-[16px] font-semibold text-neutral-400 hover:bg-neutral-50"
+                  onClick={handleLoadMore}
+                >
+                  더보기 ({enrolledLectures.length - visibleLectures})
+                </Button>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/app/(dashboard)/educators/students/page.tsx
+++ b/src/app/(dashboard)/educators/students/page.tsx
@@ -17,7 +17,10 @@ import {
   useUpdateAllAttendance,
   useUpdateEnrollment,
 } from "@/hooks/useEnrollment";
-import { STUDENT_STATUS_LABEL } from "@/constants/students.default";
+import {
+  LECTURE_FILTER_UNASSIGNED,
+  STUDENT_STATUS_LABEL,
+} from "@/constants/students.default";
 import { Pagination } from "@/components/common/pagination/Pagination";
 import { CheckModal } from "@/components/common/modals/CheckModal";
 import { getTodayYMD } from "@/utils/date";
@@ -56,6 +59,7 @@ export default function StudentsListPage() {
   const { data: lectures = [] } = useLecturesList({ page: 1, limit: 100 });
   const lectureOptions = [
     { label: "전체 수업", value: "all", status: null },
+    { label: "미배정", value: LECTURE_FILTER_UNASSIGNED, status: null },
     ...lectures.map((l) => ({
       label: l.title,
       value: l.id,
@@ -101,9 +105,14 @@ export default function StudentsListPage() {
   const { mutate: updateAllAttendance, isPending: isUpdating } =
     useUpdateAllAttendance();
 
+  const attendanceLectureId =
+    query.lecture && query.lecture !== LECTURE_FILTER_UNASSIGNED
+      ? query.lecture
+      : null;
+
   // 현재 선택된 수업의 상세 정보 찾기
-  const selectedLectureInfo = query.lecture
-    ? lectures.find((l) => l.id === query.lecture)
+  const selectedLectureInfo = attendanceLectureId
+    ? lectures.find((l) => l.id === attendanceLectureId)
     : null;
 
   // 현재 페이지의 모든 학생이 선택되었는지 여부 확인
@@ -119,7 +128,7 @@ export default function StudentsListPage() {
         name: s.studentName,
         phoneNumber: s.studentPhone,
         parentPhone: s.parentPhone,
-        title: s.lecture.title,
+        title: s.lecture?.title || "-",
       }));
       addStudents(studentsToSelect);
     } else {
@@ -167,7 +176,7 @@ export default function StudentsListPage() {
   };
 
   const handleAttendanceClick = () => {
-    if (selectedStudentIds.length === 0 || !query.lecture) return;
+    if (selectedStudentIds.length === 0 || !attendanceLectureId) return;
 
     openModal(
       <CheckModal
@@ -177,7 +186,7 @@ export default function StudentsListPage() {
         onConfirm={() => {
           updateAllAttendance(
             {
-              lectureId: query.lecture ?? "",
+              lectureId: attendanceLectureId,
               enrollmentIds: selectedStudentIds,
               status: "PRESENT",
             },
@@ -205,7 +214,7 @@ export default function StudentsListPage() {
         name: student.studentName,
         phoneNumber: student.studentPhone,
         parentPhone: student.parentPhone,
-        title: student.lecture.title,
+        title: student.lecture?.title || "-",
       }),
     onNavigate: handleNavigate,
     onStatusChange: handleStatusChange,
@@ -232,7 +241,7 @@ export default function StudentsListPage() {
 
       <StudentActions
         selectedStudentIds={selectedStudentIds}
-        queryLecture={query.lecture ?? null}
+        queryLecture={attendanceLectureId}
         isUpdating={isUpdating}
         selectedLectureStatus={selectedLectureInfo?.status}
         onAttendanceClick={handleAttendanceClick}

--- a/src/constants/students.default.ts
+++ b/src/constants/students.default.ts
@@ -39,6 +39,8 @@ export const STATUS_SELECT_OPTIONS = [
   ...STATUS_SETTING_OPTIONS,
 ];
 
+export const LECTURE_FILTER_UNASSIGNED = "unassigned" as const;
+
 // 앱 설치 상태 매핑
 export const APP_INSTALL_LABEL = {
   INSTALLED: { label: "가입", color: "green" },

--- a/src/hooks/lectures/useDeleteLecture.ts
+++ b/src/hooks/lectures/useDeleteLecture.ts
@@ -17,6 +17,7 @@ export const useDeleteLecture = (options?: UseDeleteLectureOptions) => {
       queryClient.invalidateQueries({ queryKey: lectureKeys.lists() });
       queryClient.invalidateQueries({ queryKey: lectureKeys.todays() });
       queryClient.invalidateQueries({ queryKey: lectureKeys.all });
+      queryClient.invalidateQueries({ queryKey: ["enrollments"] });
       options?.onSuccess?.();
     },
     onError: (error) => {

--- a/src/types/students.type.ts
+++ b/src/types/students.type.ts
@@ -75,7 +75,7 @@ export type GetEnrollmentList = {
   };
   lecture: {
     title: string;
-  };
+  } | null;
 };
 
 // 수강생 목록 조회 페이지네이션


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #이슈번호

## ✨ 작업 단계 및 변경 사항

- **작업 단계:** `hotfix`
- **변경 사항:**
- 백엔드 lecture=unassigned에 맞춰 수업 미배정 필터를 학생 관리에 반영
- 강의 삭제 직후 학생 목록이 바로 반영되도록 enrollments 캐시 무효화
- 일괄 출결은 실강의 id가 있을 때만 동작(미배정 학생은 전체 출결/개별 출결 모두 비활성)
- 미배정 학생 상세 페이지 `배정된 수업이 없습니다.` 알림 표시

## 🧪 테스트 방법

리뷰어가 확인해야 할 핵심 포인트를 적어주세요.

- [ ] 브라우저에서 ID: B0 페이지가 정상적으로 렌더링되는가?
- [ ] Phase 1 기준, 버튼 클릭 시 콘솔에 로그가 잘 찍히는가?

## 📸 스크린샷 (선택)

- 전체 학생
<img width="1920" height="901" alt="{3ED37AEE-57A1-41AC-B57F-135C2B8CB35D}" src="https://github.com/user-attachments/assets/75c7790e-ae65-4f54-9d1b-1960e5c2874b" />

- 미배정 필터
<img width="1920" height="898" alt="{62376355-C996-463B-8F64-8373C4CB2615}" src="https://github.com/user-attachments/assets/55ebae7c-2c71-4c97-a70e-6fdbf0bdff93" />

- 미배정 학생들은 출결 기능 제외(학생 7의 출결라벨은 강의가 있던 시기에 테스트한 기록)
<img width="1920" height="902" alt="{25DD1D81-A068-4D6F-9AE5-7ADB95620ED3}" src="https://github.com/user-attachments/assets/95ff267b-bf8c-4359-b28e-6213cd8cc982" />

- 미배정 학생 상세 페이지(미배정 알림 & 출결 버튼 비활성)
<img width="1918" height="903" alt="{4920B690-ADD2-43D8-AD82-AF4FCFC61606}" src="https://github.com/user-attachments/assets/2545ba01-a125-416c-a377-94fafd2c4099" />


## ✅ 체크리스트

- [ ] `Phase`에 맞는 이슈 체크리스트를 모두 완료했는가?
- [ ] lint / type-check 통과 및 불필요한 console.log 제거
- [ ] **머지 후 이 이슈가 [QA] 컬럼으로 이동함을 인지하고 있는가?**
